### PR TITLE
fix: uninitialized GameObject variables

### DIFF
--- a/src/engine/gameObject.cpp
+++ b/src/engine/gameObject.cpp
@@ -14,11 +14,19 @@
 // Create global macro or sum for size instead of 3?
 GameObject::GameObject()
 	: deleteObject{false},
-	  srcRect{0, 0, 32, 32}, destRect{0, 0, srcRect.w * 3, srcRect.h * 3},
-	  pivotOffset{0, 0}, isAnimated{false}, animationCounter{0}, animationSequence{0}, prevFrame{0},
-	  boundingCircle{500.0f}, useCollision{false}, collisionList{}, collisionType{},
-	  rotation{0}, flipType{SDL_FLIP_NONE}
-{}
+	  srcRect{0, 0, 32, 32},
+	  destRect{0, 0, srcRect.w * 3, srcRect.h * 3},
+	  pivotOffset{0, 0},
+	  isAnimated{false},
+	  animationCounter{0},
+	  animationSequence{0},
+	  prevFrame{0},
+	  boundingCircle{500.0f},
+	  useCollision{false},
+	  collisionList{},
+	  collisionType{},
+	  rotation{0},
+	  flipType{SDL_FLIP_NONE} {}
 
 void GameObject::initialize(const vector2Df& startPosition, const Scene& scene) {
 	// Load texture


### PR DESCRIPTION
Fixes #82
Add variables to GameObject initialization list. Some were moved out of the normal constructor, as they were only being initialized anyways, and others out of `GameObject::initialize()` because they are more appropriate in the initializer list.