### PR TITLE
fix(terrain): range destruction not working with camera

### DIFF
--- a/src/scenes/combat_scene.cpp
+++ b/src/scenes/combat_scene.cpp
@@ -24,7 +24,8 @@ void CombatScene::initialize(GameObjectVector& persistentObjects) {
 
 void CombatScene::update(const float deltaTime) {
 	if (getGame().getOnMouseDown()[SDL_BUTTON_RIGHT]) {
-		terrainManager.removeInRange(getGame().getMousePos(), 5);
+		const Vec2 pos = getGame().getMousePos() + cam.getPos();
+		terrainManager.removeInRange(pos, 5);
 	}
 
 	Scene::update(deltaTime);


### PR DESCRIPTION
Fixes #135
Add camera position to the mouse position to convert screen position to world position.