### PR TITLE
fix(terrain): wrong pixel removed on bullet collision

### DIFF
--- a/include/terrain/terrainManager.h
+++ b/include/terrain/terrainManager.h
@@ -24,12 +24,19 @@ public:
 	void render(SDL_Renderer* renderer, const Camera& cam) const;
 
 	void removePixel(const Vec2& position);
+	void removePixel(const std::pair<int, int>& position);
 	/*
 	 * @abstract	Removes all pixels in range of the center and recalculates collisions.
 	 * @param	center	Center position to remove from.
 	 * @param	range	The range to remove from. (Radius of circle).
 	 */
 	void removeInRange(const Vec2& center, const int range);
+	/*
+	 * @abstract	Get the array indices of the terrain pixel at the given world position.
+	 * @param	position	Position to translate to indices.
+	 * @return	Array indices of the world position.
+	 */
+	std::pair<int, int> posToTerrainCoord(const Vec2& position) const;
 
 	const Tree2D& getTree() const { return terrainTree; }
 
@@ -63,13 +70,6 @@ private:
 	 */
 	void tryExtendCollider(const std::pair<int, int>& start, const std::pair<int, int>& end,
 						   std::map<std::pair<int, int>, std::pair<int, int>>& currentColliders);
-
-	/*
-	 * @abstract	Get the array indices of the terrain pixel at the given world position.
-	 * @param	position	Position to translate to indices.
-	 * @return	Array indices of the world position.
-	 */
-	std::pair<int, int> posToTerrainCoord(const Vec2& position) const;
 
 	SDL_Color color;
 };

--- a/src/terrain/terrainManager.cpp
+++ b/src/terrain/terrainManager.cpp
@@ -181,7 +181,12 @@ void TerrainManager::render(SDL_Renderer* renderer, const Camera& cam) const {
 }
 
 void TerrainManager::removePixel(const Vec2& position) {
-	const auto [x, y] = posToTerrainCoord(position);
+	const auto pixelPos = posToTerrainCoord(position);
+	removePixel(pixelPos);
+}
+
+void TerrainManager::removePixel(const std::pair<int, int>& position) {
+	const auto [x, y] = position;
 	if (x >= xSize || y >= ySize || !terrainMap[x][y]) return;
 
 	terrainMap[x][y] = false;


### PR DESCRIPTION
Fixes #120

Problem:
Due to how the pixel to remove was calculated it could sometimes remove one that should not be able to be hit, for example when shooting diagonally it would register behind the two pixels one would expect to be hit.

Solution:
Check if the calculated position differs from the collision position on more than one axis, and if so choose the one that differs the least.