### PR TITLE
fix: memory leak Tree2D

### DIFF
--- a/include/enemyManager.h
+++ b/include/enemyManager.h
@@ -14,12 +14,12 @@ public:
 	void update(Scene& scene, const float deltaTime);
 
 	// Returns a vector of all enemies
-	const std::vector<Enemy*> getEnemies() const { return enemies; }
+	const std::vector<std::reference_wrapper<Enemy>>& getEnemies() const { return enemies; }
 	// Returns the position of the closest enemy
 	const Enemy* findClosestEnemy(const Vec2& target) const;
 
 private:
-	std::vector<Enemy*> enemies;
+	std::vector<std::reference_wrapper<Enemy>> enemies;
 	constexpr static float spawnInterval = 3;
 	float spawnTimer = 0;
 

--- a/include/enemyManager.h
+++ b/include/enemyManager.h
@@ -27,6 +27,6 @@ private:
 
 	void spawnEnemy(Scene& scene);
 
-	std::unique_ptr<Tree2D> enemyTree;
+	Tree2D enemyTree;
 	void updateTree();
 };

--- a/include/engine/Tree2D.h
+++ b/include/engine/Tree2D.h
@@ -11,14 +11,13 @@ class GameObject;
 // Two dimensional KD-Tree structure
 class Tree2D {
 public:
+	// Initializes the tree with the given list. Guarantees a balanced tree.
+	Tree2D(const std::vector<std::reference_wrapper<GameObject>>& objects);
 	Tree2D();
 
-	// Initializes the tree with the given list.
-	// Guarantees a balanced tree.
-	void initializeWithList(const std::vector<std::reference_wrapper<GameObject>>& objects);
-
-	// Inserts an object into the tree.
-	// NOTE: this can not guarantee a balanced tree.
+	/* Inserts an object into the tree.
+	 * NOTE: this can not guarantee a balanced tree.
+	 */
 	void insert(GameObject& object);
 
 	// Prints the tree to the console

--- a/include/engine/Tree2D.h
+++ b/include/engine/Tree2D.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <array>
-#include <list>
+#include <memory>
 #include <vector>
 
 #include "engine/vector2D.h"
@@ -11,17 +11,15 @@ class GameObject;
 // Two dimensional KD-Tree structure
 class Tree2D {
 public:
-	// Constructor to initialize root to nullptr
 	Tree2D();
-	~Tree2D();
 
 	// Initializes the tree with the given list.
 	// Guarantees a balanced tree.
-	void initializeWithList(const std::vector<GameObject*>& objects);
+	void initializeWithList(const std::vector<std::reference_wrapper<GameObject>>& objects);
 
 	// Inserts an object into the tree.
 	// NOTE: this can not guarantee a balanced tree.
-	void insert(GameObject* object);
+	void insert(GameObject& object);
 
 	// Prints the tree to the console
 	void print() const;
@@ -30,40 +28,42 @@ public:
 	GameObject* findClosestObject(const Vec2& target) const;
 
 	// Returns an std::vector of the k closest objects that are not the same as target
-	std::vector<GameObject*> findKClosestObjects(const Vec2& target, const int k) const;
+	std::vector<std::reference_wrapper<GameObject>> findKClosestObjects(const Vec2& target,
+	                                                                    const int k) const;
 
 	// Returns an std::vector of all GameObjects within the given range.
 	// Includes objects where the distance is zero, unlike the other queries.
-	std::vector<GameObject*> findObjectsInRange(const Vec2& target, const float range) const;
+	std::vector<std::reference_wrapper<GameObject>> findObjectsInRange(const Vec2& target,
+	                                                                   const float range) const;
 
 private:
 	struct Node {
 		const std::array<float, 2> point;
-		Node* left;
-		Node* right;
-		GameObject* object;
+		std::unique_ptr<Node> left;
+		std::unique_ptr<Node> right;
+		GameObject& object;
 
-		Node(const std::array<float, 2> pt, GameObject* obj);
-		~Node();
+		Node(const std::array<float, 2> pt, GameObject& obj);
 	};
 
-	Node* root;
+	std::unique_ptr<Node> root;
 
-	void initializeTree(const std::vector<GameObject*>& objects);
-	Node* insertRecursive(Node* node, const std::array<float, 2> point, GameObject* object,
-	                      const int depth);
+	void initializeTree(const std::vector<std::reference_wrapper<GameObject>>& objects);
+	void insertRecursive(Node* node, const std::array<float, 2> point, GameObject& object,
+	                     const int depth);
 
-	const Node* nearestNeighbor(const Node* node, const std::array<float, 2>& target,
+	const Node* nearestNeighbor(const Node& node, const std::array<float, 2>& target,
 	                            const int depth) const;
 
-	const Node* kNearestNeighbors(const Node* node, const std::array<float, 2>& target,
-	                              const int depth, std::list<std::pair<float, const Node*>>& heap,
-	                              const int k) const;
-	void updateHeap(std::list<std::pair<float, const Node*>>& heap, const Node* node,
-	                const std::array<float, 2>& target, const int k) const;
+	const Node* kNearestNeighbors(
+	    const Node& node, const std::array<float, 2>& target, const int depth,
+	    std::vector<std::pair<float, std::reference_wrapper<const Node>>>& heap, const int k) const;
+	void updateHeap(std::vector<std::pair<float, std::reference_wrapper<const Node>>>& heap,
+	                const Node& node, const std::array<float, 2>& target, const int k) const;
 
-	void nodesInRange(const Node* node, const std::array<float, 2>& target, const int depth,
-	                  const float range, std::vector<const Node*>& nodesList) const;
+	void nodesInRange(const Node& node, const std::array<float, 2>& target, const int depth,
+	                  const float range,
+	                  std::vector<std::reference_wrapper<const Node>>& nodesList) const;
 
 	inline float distanceSquared(const std::array<float, 2>& a,
 	                             const std::array<float, 2>& b) const {
@@ -76,5 +76,5 @@ private:
 	                            const Node* b) const;
 
 	// Prints the tree
-	void printRecursive(Node* node, int depth) const;
+	void printRecursive(const Node& node, int depth) const;
 };

--- a/include/terrain/terrainManager.h
+++ b/include/terrain/terrainManager.h
@@ -65,7 +65,7 @@ private:
 	// DEPRECATED. TerrainManager does not know about all it's terrainColliders.
 	std::vector<GameObject*> terrainColliders;
 	Tree2D terrainTree;
-	void updateTree();
+	void updateTree() {}
 
 	SDL_Color color;
 };

--- a/src/enemyManager.cpp
+++ b/src/enemyManager.cpp
@@ -1,7 +1,5 @@
 #include "enemyManager.h"
 
-#include <ranges>
-
 #include "enemies/spider.h"
 #include "engine/game.h"
 #include "engine/scene.h"
@@ -31,7 +29,7 @@ void EnemyManager::update(Scene& scene, const float deltaTime) {
 const Enemy* EnemyManager::findClosestEnemy(const Vec2& target) const {
 	try {
 		// Try to return as const Enemy*
-		return static_cast<const Enemy*>(enemyTree->findClosestObject(target));
+		return static_cast<const Enemy*>(enemyTree.findClosestObject(target));
 	} catch (int e) {
 		throw e;
 		return nullptr;
@@ -47,11 +45,10 @@ void EnemyManager::spawnEnemy(Scene& scene) {
 }
 
 void EnemyManager::updateTree() {
-	enemyTree = std::make_unique<Tree2D>();
 	std::vector<std::reference_wrapper<GameObject>> objs;
 	objs.reserve(enemies.size());
 	for (Enemy& enemy : enemies) {
 		objs.emplace_back(enemy);
 	}
-	enemyTree->initializeWithList(objs);
+	enemyTree = Tree2D{objs};
 }

--- a/src/enemyManager.cpp
+++ b/src/enemyManager.cpp
@@ -48,10 +48,10 @@ void EnemyManager::spawnEnemy(Scene& scene) {
 
 void EnemyManager::updateTree() {
 	enemyTree = std::make_unique<Tree2D>();
-	auto enemiesRange =
-	    enemies | std::views::transform([](std::reference_wrapper<Enemy> enemy) -> GameObject* {
-		    return &enemy.get();
-	    });
-	std::vector<GameObject*> enemyPtrs{enemiesRange.begin(), enemiesRange.end()};
-	enemyTree->initializeWithList(enemyPtrs);
+	std::vector<std::reference_wrapper<GameObject>> objs;
+	objs.reserve(enemies.size());
+	for (Enemy& enemy : enemies) {
+		objs.emplace_back(enemy);
+	}
+	enemyTree->initializeWithList(objs);
 }

--- a/src/engine/Tree2D.cpp
+++ b/src/engine/Tree2D.cpp
@@ -6,24 +6,25 @@
 
 #include "engine/gameObject.h"
 
-Tree2D::Tree2D() : root(nullptr) {}
+Tree2D::Tree2D() : root{nullptr} {}
 
-Tree2D::~Tree2D() { delete root; }
+Tree2D::Node::Node(const std::array<float, 2> pt, GameObject& obj)
+    : point{pt}, object{obj}, left{nullptr}, right{nullptr} {}
 
-void Tree2D::initializeWithList(const std::vector<GameObject*>& objects) {
+void Tree2D::initializeWithList(const std::vector<std::reference_wrapper<GameObject>>& objects) {
 	if (objects.empty()) return;  // Cannot build tree with no points
 
 	initializeTree(objects);
 }
 
-void Tree2D::insert(GameObject* object) {
-	const std::array<float, 2> arrPoint = {object->getPosition().x, object->getPosition().y};
+void Tree2D::insert(GameObject& object) {
+	const std::array<float, 2> arrPoint = {object.getPosition().x, object.getPosition().y};
 	// Insert from root and create root if it does not exist
-	root = insertRecursive(root, arrPoint, object, 0);
+	insertRecursive(root.get(), arrPoint, object, 0);
 }
 
 void Tree2D::print() const {
-	printRecursive(root, 0);
+	printRecursive(*root, 0);
 	std::cout << std::endl;
 }
 
@@ -32,7 +33,7 @@ GameObject* Tree2D::findClosestObject(const Vec2& target) const {
 
 	// Convert vector2Df to two dimensional array
 	const std::array<float, 2> targetArr = {target.x, target.y};
-	const Node* result = nearestNeighbor(root, targetArr, 0);
+	const Node* result = nearestNeighbor(*root, targetArr, 0);
 
 	// Throw exception if result is null
 	if (result == nullptr) throw 1;
@@ -44,153 +45,152 @@ GameObject* Tree2D::findClosestObject(const Vec2& target) const {
 	// Usually happens when there is only one enemy.
 	if (result->point[0] == target.x && result->point[1] == target.y) throw 2;
 
-	return result->object;  // Return the GameObject associated with the result node
+	return &result->object;  // Return the GameObject associated with the result node
 }
 
-std::vector<GameObject*> Tree2D::findKClosestObjects(const Vec2& target, const int k) const {
+std::vector<std::reference_wrapper<GameObject>> Tree2D::findKClosestObjects(const Vec2& target,
+                                                                            const int k) const {
 	if (root == nullptr) throw 1;
 
-	// Convert vector2Df to two dimensional array
+	// Convert Vec2 to two dimensional array
 	const std::array<float, 2> targetArr = {target.x, target.y};
 
 	// Get nearest neighbors into heap
-	std::list<std::pair<float, const Node*>> heap;
-	kNearestNeighbors(root, targetArr, 0, heap, k);
+	std::vector<std::pair<float, std::reference_wrapper<const Node>>> heap;
+	kNearestNeighbors(*root, targetArr, 0, heap, k);
 
 	if (heap.size() != k) {
 		throw 3;
 	}
 
-	// Convert result to vector of vector2Df
-	std::vector<GameObject*> result;
+	std::vector<std::reference_wrapper<GameObject>> result;
 	result.reserve(k);
-	for (auto val : heap) {
-		result.push_back(val.second->object);
+	for (auto& [dist, node] : heap) {
+		result.push_back(node.get().object);
 	}
 
 	return result;
 }
 
-std::vector<GameObject*> Tree2D::findObjectsInRange(const Vec2& target, const float range) const {
+std::vector<std::reference_wrapper<GameObject>> Tree2D::findObjectsInRange(
+    const Vec2& target, const float range) const {
 	if (root == nullptr) throw 1;
 
 	// Convert vector2Df to two dimensional array
 	const std::array<float, 2> targetArr = {target.x, target.y};
 
 	// Finid all nodes in range
-	std::vector<const Node*> nodes;
-	nodesInRange(root, targetArr, 0, range * range, nodes);
+	std::vector<std::reference_wrapper<const Node>> nodes;
+	nodesInRange(*root, targetArr, 0, range * range, nodes);
 
 	// Get GameObjects from the nodes
 	auto nodesRange =
-	    nodes | std::views::transform([](const Node* node) -> GameObject* { return node->object; });
-	std::vector<GameObject*> result(nodesRange.begin(), nodesRange.end());
+	    nodes |
+	    std::views::transform(
+	        [](std::reference_wrapper<const Node> node) -> std::reference_wrapper<GameObject> {
+		        return node.get().object;
+	        });
+	std::vector<std::reference_wrapper<GameObject>> result(nodesRange.begin(), nodesRange.end());
 
-	return result;  // Return GameObjects
+	return result;
 }
 
-Tree2D::Node::Node(const std::array<float, 2> pt, GameObject* obj)
-    : point(pt), object(obj), left(nullptr), right(nullptr) {}
-
-Tree2D::Node::~Node() {
-	delete left;
-	delete right;
-}
-
-void Tree2D::initializeTree(const std::vector<GameObject*>& objects) {
+void Tree2D::initializeTree(const std::vector<std::reference_wrapper<GameObject>>& objects) {
 	// Get the positions of all the objects
-	std::vector<std::pair<std::array<float, 2>, GameObject*>> sorted;
+	std::vector<std::pair<std::array<float, 2>, std::reference_wrapper<GameObject>>> sorted;
 	sorted.reserve(objects.size());
-	for (GameObject* object : objects) {
-		const std::array<float, 2> point = {object->getPosition().x, object->getPosition().y};
+	for (auto object : objects) {
+		const std::array<float, 2> point = {object.get().getPosition().x,
+		                                    object.get().getPosition().y};
 		sorted.push_back(std::make_pair(
-		    std::array<float, 2>{object->getPosition().x, object->getPosition().y}, object));
+		    std::array<float, 2>{object.get().getPosition().x, object.get().getPosition().y},
+		    object));
 	}
 
 	// Sort objects along x-axis to find median x.
 	// This will be used to build the tree from.
-	std::sort(sorted.begin(), sorted.end());
+	std::sort(sorted.begin(), sorted.end(),
+	          [](const auto& l, const auto& r) { return l.first[0] < r.first[0]; });
 
-	std::pair<std::array<float, 2>, GameObject*>* median =
-	    &sorted[sorted.size() / 2];                  // Find the median element
-	root = new Node(median->first, median->second);  // Set median as root
+	std::pair<std::array<float, 2>, std::reference_wrapper<GameObject>>& median =
+	    sorted[sorted.size() / 2];                               // Find the median element
+	root = std::make_unique<Node>(median.first, median.second);  // Set median as root
 
 	// Insert remaining points into tree
 	for (int i = 0; i < sorted.size(); i++) {
-		if (i == sorted.size() / 2) continue;                         // Do not insert median again
-		insertRecursive(root, sorted[i].first, sorted[i].second, 0);  // Insert point
+		if (i == sorted.size() / 2) continue;  // Do not insert median again
+		insertRecursive(root.get(), sorted[i].first, sorted[i].second, 0);  // Insert point
 	}
 }
 
-Tree2D::Node* Tree2D::insertRecursive(Node* node, const std::array<float, 2> point,
-                                      GameObject* object, const int depth) {
-	// Create new node if node is null, base case
-	if (node == nullptr) {
-		return new Node(point, object);
-	}
-
+void Tree2D::insertRecursive(Node* node, const std::array<float, 2> point, GameObject& object,
+                             const int depth) {
 	const int dimension = depth % 2;  // Calculate current dimension used
 
 	// Compare point with current node
 	if (point[dimension] < node->point[dimension]) {
 		// Go left
-		node->left = insertRecursive(node->left, point, object, depth + 1);
+		if (node->left == nullptr)
+			node->left = std::make_unique<Node>(point, object);
+		else
+			insertRecursive(node->left.get(), point, object, depth + 1);
 	} else {
 		// Go right
-		node->right = insertRecursive(node->right, point, object, depth + 1);
+		if (node->right == nullptr)
+			node->right = std::make_unique<Node>(point, object);
+		else
+			insertRecursive(node->right.get(), point, object, depth + 1);
 	}
-
-	return node;
 }
 
 // Returns the point closest to the target that is not the same as target
-const Tree2D::Node* Tree2D::nearestNeighbor(const Node* node, const std::array<float, 2>& target,
+const Tree2D::Node* Tree2D::nearestNeighbor(const Node& node, const std::array<float, 2>& target,
                                             const int depth) const {
 	// No possible paths from this node, return this node
-	if (node->left == nullptr && node->right == nullptr) return node;
+	if (node.left == nullptr && node.right == nullptr) return &node;
 
 	const int dimension = depth % 2;  // Calculate the current dimension of the tree
 
-	Node* nextBranch;
-	Node* otherBranch;
+	const Node* nextBranch;
+	const Node* otherBranch;
 
 	// Compare target with current node
-	if (target[dimension] < node->point[dimension]) {
+	if (target[dimension] < node.point[dimension]) {
 		// Go left
-		nextBranch = node->left;
-		otherBranch = node->right;
+		nextBranch = node.left.get();
+		otherBranch = node.right.get();
 	} else {
 		// Go right
-		nextBranch = node->right;
-		otherBranch = node->left;
+		nextBranch = node.right.get();
+		otherBranch = node.left.get();
 	}
 
 	const Node* result = nullptr;
 	if (nextBranch != nullptr) {  // Check that nextBranch exists
 		// Recursively go through tree
-		result = nearestNeighbor(nextBranch, target, depth + 1);
+		result = nearestNeighbor(*nextBranch, target, depth + 1);
 	}
 
 	// AFTER RECURSION
 	// Get the closest of the result and the current node
-	const Node* closest = findClosestNode(target, result, node);
+	const Node* closest = findClosestNode(target, result, &node);
 
 	if (closest == nullptr) {  // Both result and node are the same as target
-		if (!otherBranch) return nullptr;
+		if (otherBranch == nullptr) return nullptr;
 		// Try to find a valid node under other branch
-		return nearestNeighbor(otherBranch, target, depth + 1);
+		return nearestNeighbor(*otherBranch, target, depth + 1);
 	}
 
 	// Calculate distance from target to the closest node
 	float radiusSquared = distanceSquared(target, closest->point);
 	// Calculate distance from target to the split made by this node
-	float dist = target[dimension] - node->point[dimension];
+	float dist = target[dimension] - node.point[dimension];
 
 	// If distance to split is smaller than to the closest node there is a possibility that
 	// there exists a closer node in that branch of the tree
 	if (dist * dist <= radiusSquared && otherBranch != nullptr) {
 		// Recursively get the of result the other branch
-		result = nearestNeighbor(otherBranch, target, depth + 1);
+		result = nearestNeighbor(*otherBranch, target, depth + 1);
 		// Check if that result is closer than the currently closest node
 		closest = findClosestNode(target, result, closest);
 	}
@@ -198,15 +198,14 @@ const Tree2D::Node* Tree2D::nearestNeighbor(const Node* node, const std::array<f
 	return closest;
 }
 
-const Tree2D::Node* Tree2D::kNearestNeighbors(const Node* node, const std::array<float, 2>& target,
-                                              const int depth,
-                                              std::list<std::pair<float, const Node*>>& heap,
-                                              const int k) const {
+const Tree2D::Node* Tree2D::kNearestNeighbors(
+    const Node& node, const std::array<float, 2>& target, const int depth,
+    std::vector<std::pair<float, std::reference_wrapper<const Node>>>& heap, const int k) const {
 	// Check every visited node against heap
 	updateHeap(heap, node, target, k);
 
 	// No possible paths from this node
-	if (node->left == nullptr && node->right == nullptr) return node;  // Return this node
+	if (node.left == nullptr && node.right == nullptr) return &node;  // Return this node
 
 	const int dimension = depth % 2;  // Calculate the current dimension of the tree
 
@@ -214,43 +213,43 @@ const Tree2D::Node* Tree2D::kNearestNeighbors(const Node* node, const std::array
 	Node* otherBranch;
 
 	// Compare target with current node
-	if (target[dimension] < node->point[dimension]) {
+	if (target[dimension] < node.point[dimension]) {
 		// Go left
-		nextBranch = node->left;
-		otherBranch = node->right;
+		nextBranch = node.left.get();
+		otherBranch = node.right.get();
 	} else {
 		// Go right
-		nextBranch = node->right;
-		otherBranch = node->left;
+		nextBranch = node.right.get();
+		otherBranch = node.left.get();
 	}
 
 	const Node* result = nullptr;
 	if (nextBranch != nullptr) {  // Check that nextBranch exists
 		// Recursively go through tree
-		result = kNearestNeighbors(nextBranch, target, depth + 1, heap, k);
+		result = kNearestNeighbors(*nextBranch, target, depth + 1, heap, k);
 	}
 
 	// AFTER RECURSION
 	// Get the closest of the result and the current node
-	const Node* closest = findClosestNode(target, result, node);
+	const Node* closest = findClosestNode(target, result, &node);
 
 	if (closest == nullptr) {  // Both result and node are the same as target
-		if (!otherBranch) return nullptr;
+		if (otherBranch == nullptr) return nullptr;
 		// Try to find a valid node under the other branch
-		return kNearestNeighbors(otherBranch, target, depth + 1, heap, k);
+		return kNearestNeighbors(*otherBranch, target, depth + 1, heap, k);
 	}
 
 	// Calculate distance from target to the closest node
 	float radiusSquared = distanceSquared(target, closest->point);
 	// Calculate distance from target to the split made by this node
-	float dist = target[dimension] - node->point[dimension];
+	float dist = target[dimension] - node.point[dimension];
 
 	// If distance to split is smaller than to the closest node there is a possibility that
 	// there exists a closer node in that branch of the tree.
 	// Must check other branch if heap is not the asked size.
 	if ((dist * dist <= radiusSquared || heap.size() < k) && otherBranch != nullptr) {
 		// Recursively get the result of the other branch
-		result = kNearestNeighbors(otherBranch, target, depth + 1, heap, k);
+		result = kNearestNeighbors(*otherBranch, target, depth + 1, heap, k);
 		// Check if that result is closer than the currently closest node
 		closest = findClosestNode(target, result, closest);
 	}
@@ -258,16 +257,17 @@ const Tree2D::Node* Tree2D::kNearestNeighbors(const Node* node, const std::array
 	return closest;
 }
 
-void Tree2D::nodesInRange(const Node* node, const std::array<float, 2>& target, const int depth,
-                          const float range, std::vector<const Node*>& nodesList) const {
+void Tree2D::nodesInRange(const Node& node, const std::array<float, 2>& target, const int depth,
+                          const float range,
+                          std::vector<std::reference_wrapper<const Node>>& nodesList) const {
 	// Check if current node is inside range
-	const float targetDist = distanceSquared(node->point, target);
+	const float targetDist = distanceSquared(node.point, target);
 	if (targetDist <= range) {
 		nodesList.push_back(node);
 	}
 
 	// No possible paths from this node, exit recursion
-	if (node->left == nullptr && node->right == nullptr) return;
+	if (node.left == nullptr && node.right == nullptr) return;
 
 	const int dimension = depth % 2;  // Calculate the current dimension of the tree
 
@@ -275,48 +275,48 @@ void Tree2D::nodesInRange(const Node* node, const std::array<float, 2>& target, 
 	Node* otherBranch;
 
 	// Compare target with current node
-	if (target[dimension] < node->point[dimension]) {
+	if (target[dimension] < node.point[dimension]) {
 		// Go left
-		nextBranch = node->left;
-		otherBranch = node->right;
+		nextBranch = node.left.get();
+		otherBranch = node.right.get();
 	} else {
 		// Go right
-		nextBranch = node->right;
-		otherBranch = node->left;
+		nextBranch = node.right.get();
+		otherBranch = node.left.get();
 	}
 
 	if (nextBranch != nullptr) {  // Check that nextBranch exists
 		// Recursively go through tree
-		nodesInRange(nextBranch, target, depth + 1, range, nodesList);
+		nodesInRange(*nextBranch, target, depth + 1, range, nodesList);
 	}
 
 	// AFTER RECURSION
 	// Calculate distance from target to the split made by this node
-	float dist = target[dimension] - node->point[dimension];
+	float dist = target[dimension] - node.point[dimension];
 
 	// If distance to split is smaller than the search range there is a possibility that
 	// there exists a valid node in that branch of the tree
 	if (dist * dist <= range && otherBranch != nullptr) {
 		// Recursively check the other branch
-		nodesInRange(otherBranch, target, depth + 1, range, nodesList);
+		nodesInRange(*otherBranch, target, depth + 1, range, nodesList);
 	}
 }
 
-void Tree2D::updateHeap(std::list<std::pair<float, const Node*>>& heap, const Node* node,
-                        const std::array<float, 2>& target, const int k) const {
+void Tree2D::updateHeap(std::vector<std::pair<float, std::reference_wrapper<const Node>>>& heap,
+                        const Node& node, const std::array<float, 2>& target, const int k) const {
 	// Node is the same as target, invalid
-	if (target[0] == node->point[0] && target[1] == node->point[1]) return;
+	if (target[0] == node.point[0] && target[1] == node.point[1]) return;
 
 	// Get distance to check against heap
-	float dist = distanceSquared(target, node->point);
+	float dist = distanceSquared(target, node.point);
 	// Check if we should add to heap.
-	// Either distance from node is less than current max,
-	// or the heap is not large enough.
+	// Either distance from node is less than current max, or the heap is not large enough.
 	if (heap.size() < k || dist < heap.back().first) {
 		// Find position to insert in max heap
 		const auto heapPos =
-		    std::lower_bound(heap.cbegin(), heap.cend(), std::make_pair(dist, node));
-		heap.insert(heapPos, std::make_pair(dist, node));
+		    std::lower_bound(heap.cbegin(), heap.cend(), std::make_pair(dist, std::ref(node)),
+		                     [](const auto& l, const auto& r) { return l.first > r.first; });
+		heap.insert(heapPos, std::make_pair(dist, std::ref(node)));
 	}
 	// Ensure correct heap size
 	if (heap.size() > k) {
@@ -352,17 +352,15 @@ const Tree2D::Node* Tree2D::findClosestNode(const std::array<float, 2>& target, 
 		return b;
 }
 
-void Tree2D::printRecursive(Node* node, int depth) const {
-	if (node == nullptr) return;
-
+void Tree2D::printRecursive(const Node& node, int depth) const {
 	for (int i = 0; i < depth; i++) std::cout << "  ";
 	std::cout << "(";
 	for (int i = 0; i < 2; i++) {
-		std::cout << node->point[i];
+		std::cout << node.point[i];
 		if (i < 1) std::cout << ", ";
 	}
 	std::cout << ")" << std::endl;
 
-	printRecursive(node->left, depth + 1);
-	printRecursive(node->right, depth + 1);
+	if (node.left) printRecursive(*node.left, depth + 1);
+	if (node.right) printRecursive(*node.right, depth + 1);
 }

--- a/src/engine/Tree2D.cpp
+++ b/src/engine/Tree2D.cpp
@@ -8,14 +8,13 @@
 
 Tree2D::Tree2D() : root{nullptr} {}
 
-Tree2D::Node::Node(const std::array<float, 2> pt, GameObject& obj)
-    : point{pt}, object{obj}, left{nullptr}, right{nullptr} {}
-
-void Tree2D::initializeWithList(const std::vector<std::reference_wrapper<GameObject>>& objects) {
-	if (objects.empty()) return;  // Cannot build tree with no points
-
+Tree2D::Tree2D(const std::vector<std::reference_wrapper<GameObject>>& objects) : root{nullptr} {
+	if (objects.empty()) return;
 	initializeTree(objects);
 }
+
+Tree2D::Node::Node(const std::array<float, 2> pt, GameObject& obj)
+    : point{pt}, object{obj}, left{nullptr}, right{nullptr} {}
 
 void Tree2D::insert(GameObject& object) {
 	const std::array<float, 2> arrPoint = {object.getPosition().x, object.getPosition().y};

--- a/src/engine/Tree2D.cpp
+++ b/src/engine/Tree2D.cpp
@@ -19,8 +19,10 @@ void Tree2D::initializeWithList(const std::vector<std::reference_wrapper<GameObj
 
 void Tree2D::insert(GameObject& object) {
 	const std::array<float, 2> arrPoint = {object.getPosition().x, object.getPosition().y};
-	// Insert from root and create root if it does not exist
-	insertRecursive(root.get(), arrPoint, object, 0);
+	if (root == nullptr)
+		root = std::make_unique<Node>(arrPoint, object);
+	else
+		insertRecursive(root.get(), arrPoint, object, 0);
 }
 
 void Tree2D::print() const {

--- a/src/engine/Tree2D.cpp
+++ b/src/engine/Tree2D.cpp
@@ -317,7 +317,7 @@ void Tree2D::updateHeap(std::vector<std::pair<float, std::reference_wrapper<cons
 		// Find position to insert in max heap
 		const auto heapPos =
 		    std::lower_bound(heap.cbegin(), heap.cend(), std::make_pair(dist, std::ref(node)),
-		                     [](const auto& l, const auto& r) { return l.first > r.first; });
+		                     [](const auto& l, const auto& r) { return l.first < r.first; });
 		heap.insert(heapPos, std::make_pair(dist, std::ref(node)));
 	}
 	// Ensure correct heap size

--- a/src/engine/collision.cpp
+++ b/src/engine/collision.cpp
@@ -294,7 +294,7 @@ void Collider::onCollision(const Collision::Event& event, Scene& scene) {
 }
 
 void CircleCollider::checkCollisions(const Scene& scene) {
-	std::vector<GameObject*> closeObjects;
+	std::vector<std::reference_wrapper<GameObject>> closeObjects;
 	try {
 		// Get all GameObjects withing our bounding circle
 		closeObjects = scene.getObjectTree().findObjectsInRange(circle.position, getCheckRadius());
@@ -303,13 +303,13 @@ void CircleCollider::checkCollisions(const Scene& scene) {
 		return;
 	}
 
-	for (GameObject* object : closeObjects) {
-		Collider* otherCollider = object->getCollider();
+	for (GameObject& object : closeObjects) {
+		Collider* otherCollider = object.getCollider();
 		// No need to check collision if object is not collideable,
 		// or we know we have already collided,
 		// or if it is "colliding" with itself.
 		if (otherCollider == nullptr || haveCollidedWith.count(otherCollider) ||
-		    object == getParent())
+		    &object == getParent())
 			continue;
 
 		switch (otherCollider->getCollisionType()) {
@@ -353,7 +353,7 @@ void CircleCollider::checkCollisions(const Scene& scene) {
 }
 
 void LineCollider::checkCollisions(const Scene& scene) {
-	std::vector<GameObject*> closeObjects;
+	std::vector<std::reference_wrapper<GameObject>> closeObjects;
 	try {
 		// Get all GameObjects withing our bounding circle
 		closeObjects = scene.getObjectTree().findObjectsInRange(line.start, getCheckRadius());
@@ -362,13 +362,13 @@ void LineCollider::checkCollisions(const Scene& scene) {
 		return;
 	}
 
-	for (GameObject* object : closeObjects) {
-		Collider* otherCollider = object->getCollider();
+	for (GameObject& object : closeObjects) {
+		Collider* otherCollider = object.getCollider();
 		// No need to check collision if object is not collideable,
 		// or we know we have already collided,
 		// or if it is "colliding" with itself.
 		if (otherCollider == nullptr || haveCollidedWith.count(otherCollider) ||
-		    object == getParent())
+		    &object == getParent())
 			continue;
 
 		switch (otherCollider->getCollisionType()) {
@@ -405,7 +405,7 @@ void LineCollider::checkCollisions(const Scene& scene) {
 }
 
 void PointCollider::checkCollisions(const Scene& scene) {
-	std::vector<GameObject*> closeObjects;
+	std::vector<std::reference_wrapper<GameObject>> closeObjects;
 	try {
 		// Get all GameObjects withing our bounding circle
 		closeObjects = scene.getObjectTree().findObjectsInRange(point, getCheckRadius());
@@ -414,13 +414,13 @@ void PointCollider::checkCollisions(const Scene& scene) {
 		return;
 	}
 
-	for (GameObject* object : closeObjects) {
-		Collider* otherCollider = object->getCollider();
+	for (GameObject& object : closeObjects) {
+		Collider* otherCollider = object.getCollider();
 		// No need to check collision if object is not collideable,
 		// or we know we have already collided,
 		// or if it is "colliding" with itself.
 		if (otherCollider == nullptr || haveCollidedWith.count(otherCollider) ||
-		    object == getParent())
+		    &object == getParent())
 			continue;
 
 		switch (otherCollider->getCollisionType()) {

--- a/src/engine/scene.cpp
+++ b/src/engine/scene.cpp
@@ -55,15 +55,12 @@ void Scene::render(SDL_Renderer* renderer) const {
 }
 
 void Scene::updateObjectTree() {
-	objectTree = Tree2D();  // Create new tree
-
-	// Create vector of raw pointers from unique_ptr vector
+	// Create vector of references from unique_ptr vector
 	const auto objectsRange =
 	    gameObjects |
 	    std::views::transform(
 	        [](const std::unique_ptr<GameObject>& ptr) -> GameObject& { return *ptr; });
 	const std::vector<std::reference_wrapper<GameObject>> objects(objectsRange.begin(),
 	                                                              objectsRange.end());
-
-	objectTree.initializeWithList(objects);
+	objectTree = Tree2D{objects};
 }

--- a/src/engine/scene.cpp
+++ b/src/engine/scene.cpp
@@ -61,9 +61,9 @@ void Scene::updateObjectTree() {
 	const auto objectsRange =
 	    gameObjects |
 	    std::views::transform(
-	        [](const std::unique_ptr<GameObject>& ptr) -> GameObject* { return ptr.get(); });
-	const std::vector<GameObject*> rawObjects(objectsRange.begin(), objectsRange.end());
+	        [](const std::unique_ptr<GameObject>& ptr) -> GameObject& { return *ptr; });
+	const std::vector<std::reference_wrapper<GameObject>> objects(objectsRange.begin(),
+	                                                              objectsRange.end());
 
-	// Create the tree from the GameObject vector
-	objectTree.initializeWithList(rawObjects);
+	objectTree.initializeWithList(objects);
 }

--- a/src/terrain/terrainManager.cpp
+++ b/src/terrain/terrainManager.cpp
@@ -40,11 +40,6 @@ void TerrainManager::updateColliders() {
 	updateTree();
 }
 
-void TerrainManager::updateTree() {
-	terrainTree = Tree2D{};
-	terrainTree.initializeWithList(terrainColliders);
-}
-
 void TerrainManager::render(SDL_Renderer* renderer, const Camera& cam) const {
 	SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, color.a);
 

--- a/test/Tree2D_test.cpp
+++ b/test/Tree2D_test.cpp
@@ -20,7 +20,9 @@ std::vector<GameObject*> makePtrVec(const std::vector<Vec2>& points) {
 std::vector<std::reference_wrapper<GameObject>> makeReference(
     const std::vector<GameObject*>& ptrs) {
 	auto range =
-	    ptrs | std::views::transform([](GameObject* ptr) -> std::reference_wrapper<GameObject> { return std::ref(*ptr); });
+	    ptrs | std::views::transform([](GameObject* ptr) -> std::reference_wrapper<GameObject> {
+		    return std::ref(*ptr);
+	    });
 	return std::vector<std::reference_wrapper<GameObject>>{range.begin(), range.end()};
 }
 
@@ -31,14 +33,12 @@ void testCleanup(std::vector<GameObject*>& objects) {
 }
 
 TEST(Tree2D, General) {
-	Tree2D tree;
-
 	std::vector<Vec2> points = {Vec2(3, 6), Vec2(17, 15), Vec2(13, 15), Vec2(6, 12),
 	                            Vec2(9, 1), Vec2(2, 7),   Vec2(10, 19)};
 
 	auto testDataPtr = makePtrVec(points);
 	auto testData = makeReference(testDataPtr);
-	tree.initializeWithList(testData);
+	Tree2D tree{testData};
 
 	std::array<Vec2, 7> testPoints = {Vec2(10, 10), Vec2(8, 2), Vec2(4, 7),  Vec2(16, 16),
 	                                  Vec2(12, 14), Vec2(0, 5), Vec2(11, 18)};
@@ -54,8 +54,6 @@ TEST(Tree2D, General) {
 }
 
 TEST(Tree2D, CheckingWithExistingPoints) {
-	Tree2D tree;
-
 	std::vector<Vec2> points = {
 	    Vec2(10, 10),
 	    Vec2(20, 10),
@@ -65,7 +63,7 @@ TEST(Tree2D, CheckingWithExistingPoints) {
 
 	auto testDataPtr = makePtrVec(points);
 	auto testData = makeReference(testDataPtr);
-	tree.initializeWithList(testData);
+	Tree2D tree{testData};
 
 	std::array<Vec2, 2> testPoints = {Vec2(10, 10), Vec2(10, 5)};
 
@@ -139,14 +137,12 @@ TEST(Tree2D, DuplicateSinglePoints) {
 }
 
 TEST(Tree2D, MultiplePointQuery) {
-	Tree2D tree;
-
 	std::vector<Vec2> points = {Vec2(3, 6), Vec2(17, 15), Vec2(13, 15), Vec2(6, 12),
 	                            Vec2(9, 2), Vec2(2, 7),   Vec2(10, 19)};
 
 	auto testDataPtr = makePtrVec(points);
 	auto testData = makeReference(testDataPtr);
-	tree.initializeWithList(testData);
+	Tree2D tree{testData};
 
 	std::array<Vec2, 3> testPoints = {Vec2(2, 5), Vec2(12, 12), Vec2(25, 5)};
 
@@ -198,14 +194,12 @@ TEST(Tree2D, MultiplePoint_DuplicatePoints) {
 }
 
 TEST(Tree2D, ObjectsInRange) {
-	Tree2D tree;
-
 	std::vector<Vec2> points = {Vec2(3, 6), Vec2(17, 15), Vec2(13, 15), Vec2(6, 12),
 	                            Vec2(9, 2), Vec2(2, 7),   Vec2(10, 19)};
 
 	auto testDataPtr = makePtrVec(points);
 	auto testData = makeReference(testDataPtr);
-	tree.initializeWithList(testData);
+	Tree2D tree{testData};
 
 	std::array<Vec2, 3> testPoints{Vec2(12, 12), Vec2(25, 5), Vec2(2, 7)};
 	std::array<float, testPoints.size()> testRanges{6, 17.5, 10};

--- a/test/Tree2D_test.cpp
+++ b/test/Tree2D_test.cpp
@@ -2,17 +2,26 @@
 
 #include <gtest/gtest.h>
 
+#include <ranges>
+
 #include "engine/gameObject.h"
 #include "mockGameObject.h"
 
-std::vector<GameObject*> testInit(const std::vector<Vec2>& points) {
+std::vector<GameObject*> makePtrVec(const std::vector<Vec2>& points) {
 	std::vector<MockGameObject*> objects;
 	objects.reserve(points.size());
 	for (const Vec2& point : points) {
-		objects.push_back(new MockGameObject(point));
+		objects.push_back(new MockGameObject{point});
 	}
 
 	return std::vector<GameObject*>(objects.begin(), objects.end());
+}
+
+std::vector<std::reference_wrapper<GameObject>> makeReference(
+    const std::vector<GameObject*>& ptrs) {
+	auto range =
+	    ptrs | std::views::transform([](GameObject* ptr) -> std::reference_wrapper<GameObject> { return std::ref(*ptr); });
+	return std::vector<std::reference_wrapper<GameObject>>{range.begin(), range.end()};
 }
 
 void testCleanup(std::vector<GameObject*>& objects) {
@@ -27,7 +36,8 @@ TEST(Tree2D, General) {
 	std::vector<Vec2> points = {Vec2(3, 6), Vec2(17, 15), Vec2(13, 15), Vec2(6, 12),
 	                            Vec2(9, 1), Vec2(2, 7),   Vec2(10, 19)};
 
-	auto testData = testInit(points);
+	auto testDataPtr = makePtrVec(points);
+	auto testData = makeReference(testDataPtr);
 	tree.initializeWithList(testData);
 
 	std::array<Vec2, 7> testPoints = {Vec2(10, 10), Vec2(8, 2), Vec2(4, 7),  Vec2(16, 16),
@@ -40,7 +50,7 @@ TEST(Tree2D, General) {
 		EXPECT_TRUE(result == expected[i]) << "Expected: " << expected[i] << " Found: " << result;
 	}
 
-	testCleanup(testData);
+	testCleanup(testDataPtr);
 }
 
 TEST(Tree2D, CheckingWithExistingPoints) {
@@ -53,7 +63,8 @@ TEST(Tree2D, CheckingWithExistingPoints) {
 	    Vec2(5, 20),
 	};
 
-	auto testData = testInit(points);
+	auto testDataPtr = makePtrVec(points);
+	auto testData = makeReference(testDataPtr);
 	tree.initializeWithList(testData);
 
 	std::array<Vec2, 2> testPoints = {Vec2(10, 10), Vec2(10, 5)};
@@ -65,14 +76,14 @@ TEST(Tree2D, CheckingWithExistingPoints) {
 		EXPECT_TRUE(result == expected[i]) << "Expected: " << expected[i] << " Found: " << result;
 	}
 
-	testCleanup(testData);
+	testCleanup(testDataPtr);
 }
 
 TEST(Tree2D, SinglePoint) {
 	Tree2D tree;
 
 	auto object = std::make_unique<MockGameObject>(Vec2(10, 10));
-	tree.insert(object.get());
+	tree.insert(*object);
 
 	std::array<Vec2, 2> testPoints = {Vec2(10, 10), Vec2(10, 5)};
 
@@ -94,7 +105,7 @@ TEST(Tree2D, DuplicatePoints) {
 	objects.push_back(std::move(std::make_unique<MockGameObject>(Vec2(10, 10))));
 
 	for (auto& obj : objects) {
-		tree.insert(obj.get());
+		tree.insert(*obj);
 	}
 
 	Vec2 result = tree.findClosestObject(Vec2(5, 2))->getPosition();
@@ -118,7 +129,7 @@ TEST(Tree2D, DuplicateSinglePoints) {
 	objects.push_back(std::move(std::make_unique<MockGameObject>(Vec2(5, 3))));
 
 	for (auto& obj : objects) {
-		tree.insert(obj.get());
+		tree.insert(*obj);
 	}
 
 	EXPECT_THROW(tree.findClosestObject(Vec2(5, 3)), int) << "Expected error 2 thrown.";
@@ -133,7 +144,8 @@ TEST(Tree2D, MultiplePointQuery) {
 	std::vector<Vec2> points = {Vec2(3, 6), Vec2(17, 15), Vec2(13, 15), Vec2(6, 12),
 	                            Vec2(9, 2), Vec2(2, 7),   Vec2(10, 19)};
 
-	auto testData = testInit(points);
+	auto testDataPtr = makePtrVec(points);
+	auto testData = makeReference(testDataPtr);
 	tree.initializeWithList(testData);
 
 	std::array<Vec2, 3> testPoints = {Vec2(2, 5), Vec2(12, 12), Vec2(25, 5)};
@@ -144,7 +156,7 @@ TEST(Tree2D, MultiplePointQuery) {
 	    std::vector{Vec2(17, 15), Vec2(13, 15), Vec2(9, 2), Vec2(6, 12), Vec2(10, 19), Vec2(3, 6)}};
 
 	for (int i = 0; i < testPoints.size(); i++) {
-		const std::vector<GameObject*> result =
+		const std::vector<std::reference_wrapper<GameObject>> result =
 		    tree.findKClosestObjects(testPoints[i], expected[i].size());
 
 		EXPECT_TRUE(result.size() == expected[i].size())
@@ -152,12 +164,13 @@ TEST(Tree2D, MultiplePointQuery) {
 		    << ". Subtest " << i;
 
 		for (int j = 0; j < result.size(); j++) {
-			EXPECT_TRUE(result[j]->getPosition() == expected[i][j])
-			    << "Expected: " << expected[i][j] << " Found: " << result[j] << ". Subtest " << i;
+			EXPECT_TRUE(result[j].get().getPosition() == expected[i][j])
+			    << "Expected: " << expected[i][j] << " Found: " << result[j].get().getPosition()
+			    << ". Subtest " << i;
 		}
 	}
 
-	testCleanup(testData);
+	testCleanup(testDataPtr);
 }
 
 TEST(Tree2D, MultiplePoint_DuplicatePoints) {
@@ -172,7 +185,7 @@ TEST(Tree2D, MultiplePoint_DuplicatePoints) {
 	objects.push_back(std::move(std::make_unique<MockGameObject>(Vec2(10, 10))));
 
 	for (auto& obj : objects) {
-		tree.insert(obj.get());
+		tree.insert(*obj);
 	}
 
 	EXPECT_NO_THROW(tree.findKClosestObjects(Vec2(10, 10), 2));
@@ -190,7 +203,8 @@ TEST(Tree2D, ObjectsInRange) {
 	std::vector<Vec2> points = {Vec2(3, 6), Vec2(17, 15), Vec2(13, 15), Vec2(6, 12),
 	                            Vec2(9, 2), Vec2(2, 7),   Vec2(10, 19)};
 
-	auto testData = testInit(points);
+	auto testDataPtr = makePtrVec(points);
+	auto testData = makeReference(testDataPtr);
 	tree.initializeWithList(testData);
 
 	std::array<Vec2, 3> testPoints{Vec2(12, 12), Vec2(25, 5), Vec2(2, 7)};
@@ -202,7 +216,7 @@ TEST(Tree2D, ObjectsInRange) {
 	    std::set{Vec2(3, 6), Vec2(6, 12), Vec2(9, 2), Vec2(2, 7)}};
 
 	for (int i = 0; i < testPoints.size(); i++) {
-		const std::vector<GameObject*> result =
+		const std::vector<std::reference_wrapper<GameObject>> result =
 		    tree.findObjectsInRange(testPoints[i], testRanges[i]);
 
 		EXPECT_TRUE(result.size() == expected[i].size())
@@ -210,8 +224,8 @@ TEST(Tree2D, ObjectsInRange) {
 		    << " Found: " << result.size();
 
 		std::set<Vec2> resultSet;
-		for (auto obj : result) {
-			resultSet.insert(obj->getPosition());
+		for (GameObject& obj : result) {
+			resultSet.insert(obj.getPosition());
 		}
 
 		EXPECT_TRUE(resultSet == expected[i]) << "Test " << i;
@@ -232,13 +246,14 @@ TEST(Tree2D, ObjectsInRange_OtherBranch) {
 	}
 
 	for (auto& obj : objects) {
-		tree.insert(obj.get());
+		tree.insert(*obj);
 	}
 
-	const std::vector<GameObject*> result = tree.findObjectsInRange(Vec2(10, 10), 4);
+	const std::vector<std::reference_wrapper<GameObject>> result =
+	    tree.findObjectsInRange(Vec2(10, 10), 4);
 	std::set<Vec2> resultPos;
-	for (auto& res : result) {
-		resultPos.insert(res->getPosition());
+	for (GameObject& res : result) {
+		resultPos.insert(res.getPosition());
 	}
 
 	// EXPECT_TRUE(false);


### PR DESCRIPTION
- Change to using unique_ptrs.
- Use references instead of pointers to GameObjects, and in some cases Nodes.
- Give Tree2D a constructor taking in a GameObject vector instead of a separate init function.