### PR TITLE
fix: resource manager memory leak

### DIFF
--- a/include/engine/game.h
+++ b/include/engine/game.h
@@ -7,6 +7,7 @@
 
 #include "engine/gameObject.h"
 #include "engine/renderManager.h"
+#include "engine/resourceManager.h"
 #include "engine/vector2D.h"
 
 class Scene;
@@ -39,6 +40,7 @@ public:
 	const Vec2& getWinDimensions() const { return winDimensions; }
 
 	RenderManager& getRenderManager() { return renderManager; }
+	ResourceManager& getResourceManager() { return resourceManager; }
 
 	const std::array<bool, 256>& getInput() const { return input; }
 	// Button value true if button is being held
@@ -65,4 +67,7 @@ private:
 	constexpr static const uint16_t sceneCount = 1;
 
 	RenderManager renderManager;
+
+	ResourceManager resourceManager;
+	ResourceManager initializeResourceManager() const;
 };

--- a/include/engine/gameObject.h
+++ b/include/engine/gameObject.h
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <functional>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "SDL2/SDL_render.h"
@@ -12,10 +11,10 @@
 #include "engine/vector2D.h"
 
 // Use this inside protected section of child class to set its texture
-#define SETOBJECTTEXTURE(FILE)                            \
-	const std::string& getTextureSheet() const override { \
-		static const std::string file = FILE;             \
-		return file;                                      \
+#define SETOBJECTTEXTURE(FILE)                                \
+	const std::string_view getTextureSheet() const override { \
+		static const std::string file = FILE;                 \
+		return file;                                          \
 	}
 
 class Scene;
@@ -86,7 +85,7 @@ protected:
 	Vec2 pivotOffset;
 
 	// Rendering
-	virtual const std::string& getTextureSheet() const {
+	virtual const std::string_view getTextureSheet() const {
 		static const std::string file = "default_gameobject.png";
 		return file;
 	};

--- a/include/engine/resourceManager.h
+++ b/include/engine/resourceManager.h
@@ -1,11 +1,20 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 
 #include "SDL2/SDL_render.h"
 
 class Game;
 
-namespace ResourceManager {
-SDL_Texture* LoadTexture(const std::string& filename, Game& game);
-}
+class ResourceManager {
+public:
+	ResourceManager(std::string&& assetsPath);
+
+	SDL_Texture* loadTexture(const std::string_view filename, Game& game);
+	void destroyTextures();
+
+private:
+	const std::string assetsPath;
+	std::unordered_map<std::string_view, SDL_Texture*> loadedTextures;
+};

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -12,7 +12,8 @@ Game::Game(const char* title, const int width, const int height)
       renderer{nullptr},
       input{},
       mouseInput{},
-      onMouseDown{} {
+      onMouseDown{},
+      resourceManager{initializeResourceManager()} {
 	isRunning = true;
 
 	// Check that SDL initializes
@@ -29,10 +30,13 @@ Game::Game(const char* title, const int width, const int height)
 	// Make alpha/transparency work
 	SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
 
+#ifndef ASSETS_PATH
+	std::cerr << "ERROR: ASSETS_PATH not defined. Cannot load any textures." << std::endl;
+	clean();
+	std::terminate();
+#endif
 	// Initialize prevTime to ensure correct first deltaTime
 	prevTime = SDL_GetPerformanceCounter();
-
-	renderManager = RenderManager();  // Create RenderManager
 
 	// Add scenes
 	scenes.reserve(sceneCount);
@@ -111,6 +115,8 @@ void Game::render() const {
 }
 
 void Game::clean() {
+	resourceManager.destroyTextures();
+
 	SDL_DestroyWindow(window);
 	SDL_DestroyRenderer(renderer);
 	SDL_Quit();
@@ -136,3 +142,11 @@ void Game::addScene() {
 }
 // Create all valid templates
 template void Game::addScene<CombatScene>();
+
+ResourceManager Game::initializeResourceManager() const {
+#ifndef ASSETS_PATH
+	std::cerr << "ERROR: ASSETS_PATH not defined. Cannot load any assets." << std::endl;
+	std::terminate();
+#endif
+	return ResourceManager{ASSETS_PATH};
+}

--- a/src/engine/gameObject.cpp
+++ b/src/engine/gameObject.cpp
@@ -35,7 +35,7 @@ GameObject::GameObject() : GameObject{nullptr} {}
 
 void GameObject::initialize(const Scene& scene, const Vec2& startPosition) {
 	// Load texture
-	texture = ResourceManager::LoadTexture(getTextureSheet(), scene.getGame());
+	texture = scene.getGame().getResourceManager().loadTexture(getTextureSheet(), scene.getGame());
 
 	// Initialize pivot
 	pivot.x = (float)destRect.w / 2 + pivotOffset.x;


### PR DESCRIPTION
Fixes #145 

Problem:
The textures and surfaces created when using
ResourceManager::loadTexture were not properly destroyed or freed.

Solution:
Make ResourceManager a class, which the Game instance will have as a member. Then on Game::clean destroy all created textures. Additionally, call SDL_FreeSurface on the surface created from SDL_LoadBMP, which is not automatically freed when calling SDL_CreateTextureFromSurface.