### PR TITLE
feat: chunk loading system

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DTESTING=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DTESTING=ON -DDEBUG_GIZMO=OFF
 
     - name: Fetch SDL dependencies
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,8 @@ set(SOURCE_FILES
 "src/terrain/chunk.cpp"
 )
 
-add_compile_options(-fsanitize=address)
-add_link_options(-fsanitize=address)
+#add_compile_options(-fsanitize=address)
+#add_link_options(-fsanitize=address)
 
 # Build the game as a static library
 add_library(${PROJECT_NAME}_lib STATIC ${SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ set(SOURCE_FILES
 "src/terrain/chunk.cpp"
 )
 
+add_compile_options(-fsanitize=address)
+add_link_options(-fsanitize=address)
+
 # Build the game as a static library
 add_library(${PROJECT_NAME}_lib STATIC ${SOURCE_FILES})
 

--- a/include/engine/collision.h
+++ b/include/engine/collision.h
@@ -50,8 +50,7 @@ struct Line {
 
 	Line() : start(), end() {}
 	Line(const Vec2& s, const Vec2& e) : start{s}, end{e}, position{s + (e - s) * 0.5f} {}
-	Line(const Vec2& pos, const Vec2& s, const Vec2& e)
-	    : start{s}, end{e}, position{pos} {}
+	Line(const Vec2& pos, const Vec2& s, const Vec2& e) : start{s}, end{e}, position{pos} {}
 };
 
 Vec2 closestPointOnLine(const Vec2& point, const Line& line);
@@ -90,6 +89,10 @@ public:
 	const GameObject* getParent() const { return parent; }
 	float getCheckRadius() const { return checkRadius; }
 	bool getIsStatic() const { return isStatic; }
+
+	virtual std::string_view getTag() const {
+		return "";
+	}
 
 protected:
 	/*

--- a/include/engine/collision.h
+++ b/include/engine/collision.h
@@ -44,11 +44,14 @@ struct Circle {
 };
 
 struct Line {
+	Vec2 position;
 	Vec2 start;
 	Vec2 end;
 
 	Line() : start(), end() {}
-	Line(const Vec2& s, const Vec2& e) : start(s), end(e) {}
+	Line(const Vec2& s, const Vec2& e) : start{s}, end{e}, position{s + (e - s) * 0.5f} {}
+	Line(const Vec2& pos, const Vec2& s, const Vec2& e)
+	    : start{s}, end{e}, position{pos} {}
 };
 
 Vec2 closestPointOnLine(const Vec2& point, const Line& line);

--- a/include/engine/collision.h
+++ b/include/engine/collision.h
@@ -90,9 +90,7 @@ public:
 	float getCheckRadius() const { return checkRadius; }
 	bool getIsStatic() const { return isStatic; }
 
-	virtual std::string_view getTag() const {
-		return "";
-	}
+	virtual std::string_view getTag() const { return ""; }
 
 protected:
 	/*

--- a/include/engine/scene.h
+++ b/include/engine/scene.h
@@ -21,7 +21,7 @@ public:
 	/*
 	 * @param	persistentObjects	The gameObjects this scene will be initialized with.
 	 */
-	virtual void initialize(GameObjectVector& persistentObjects);
+	virtual void initialize(GameObjectVector&& persistentObjects);
 	virtual void initialize();
 
 	/*

--- a/include/engine/scene.h
+++ b/include/engine/scene.h
@@ -68,6 +68,13 @@ protected:
 	Camera cam;
 	Game& game;
 
+	/* Updates all GameObjects according to registered collisions.
+	 * This is not automatically called inside Scene::update, and is left up to inheriting scenes
+	 * to decide when this update should happen.
+	 * If not called collisions have no effect.
+	 */
+	void updateCollision();
+
 private:
 	GameObjectVector gameObjects;
 	Tree2D objectTree;

--- a/include/scenes/combat_scene.h
+++ b/include/scenes/combat_scene.h
@@ -10,7 +10,6 @@ class CombatScene : public Scene {
 public:
 	CombatScene(Game& game_);
 
-	void initialize(GameObjectVector& persistentObjects) override;
 	void initialize() override;
 
 	void update(const float deltaTime) override;

--- a/include/terrain/chunk.h
+++ b/include/terrain/chunk.h
@@ -34,6 +34,7 @@ public:
 	void updateRender(const int pixelSize);
 
 	void updateColliders();
+	std::size_t getColliderCount() const { return colliders.size(); }
 
 	void updateSpawnPositions();
 

--- a/include/terrain/chunk.h
+++ b/include/terrain/chunk.h
@@ -10,10 +10,11 @@
 #include "terrain/terrainCollider.h"
 
 class Scene;
-class TerrainManager;
 struct Vec2;
 struct SDL_Renderer;
 class Camera;
+class TerrainChange;
+class TerrainManager;
 
 class Chunk {
 public:
@@ -23,9 +24,8 @@ public:
 	/* Sets the cell at position (x, y) to value.
 	 * x and y position is relative to this chunk.
 	 */
-	void setCell(const std::size_t x, const std::size_t y, const unsigned char value);
-	void setCellMultiple(const std::vector<std::pair<size_t, size_t>>& positions,
-	                     const unsigned char value);
+	void changeTerrain(const TerrainChange& change);
+	void changeTerrainMultiple(const std::vector<TerrainChange>& changes);
 
 	void update(Scene& scene);
 	void collisionUpdate(Scene& scene);

--- a/include/terrain/chunk.h
+++ b/include/terrain/chunk.h
@@ -27,7 +27,8 @@ public:
 	void setCellMultiple(const std::vector<std::pair<size_t, size_t>>& positions,
 	                     const unsigned char value);
 
-	void update(const float deltaTime);
+	void update(Scene& scene);
+	void collisionUpdate(Scene& scene);
 
 	void render(SDL_Renderer* renderer, const Camera& cam) const;
 	void updateRender(const int pixelSize);

--- a/include/terrain/chunk.h
+++ b/include/terrain/chunk.h
@@ -7,10 +7,10 @@
 
 #include "SDL2/SDL_rect.h"
 #include "terrain/terrain.h"
+#include "terrain/terrainCollider.h"
 
 class Scene;
 class TerrainManager;
-class TerrainCollider;
 struct Vec2;
 struct SDL_Renderer;
 class Camera;
@@ -26,6 +26,8 @@ public:
 	void setCell(const std::size_t x, const std::size_t y, const unsigned char value);
 	void setCellMultiple(const std::vector<std::pair<size_t, size_t>>& positions,
 	                     const unsigned char value);
+
+	void update(const float deltaTime);
 
 	void render(SDL_Renderer* renderer, const Camera& cam) const;
 	void updateRender(const int pixelSize);
@@ -46,7 +48,7 @@ private:
 	const std::size_t originY;
 
 	std::vector<std::vector<SDL_Rect>> renderRects;
-	std::vector<std::reference_wrapper<TerrainCollider>> colliders;
+	std::vector<TerrainCollider> colliders;
 
 	/* Tries to extend an existing collider that ends at start to ending at end.
 	 *
@@ -64,7 +66,7 @@ private:
 	 * @param end End position of LineCollider.
 	 * @param scene The scene to create the collider in.
 	 */
-	void createCollider(const Vec2& start, const Vec2& end);
+	void createCollider(Vec2&& start, Vec2&& end);
 
 	static constexpr int minSpawnSpace = 15;
 	static std::array<int, minSpawnSpace> spawnCircleY;

--- a/include/terrain/terrainCollider.h
+++ b/include/terrain/terrainCollider.h
@@ -4,22 +4,20 @@
 
 class Chunk;
 
-class TerrainCollider : public GameObject {
+class TerrainCollider {
 public:
-	TerrainCollider();
-
-	void initialize(const Scene& scene, const Vec2& position, const Vec2& start, const Vec2& end,
-	                Chunk& chunk);
+	TerrainCollider(Vec2&& position, Vec2&& start, Vec2&& end, Chunk& chunk);
 
 	// ONLY USED FOR DEBUG_GIZMO
-	void update(Scene& scene, const float deltaTime) override;
+	void update(Scene& scene, const float deltaTime);
 
-	void onCollision(const Collision::Event& event, Scene& scene) override;
+	void onCollision(const Collision::Event& event, Scene& scene);
 
 private:
-	SETOBJECTTEXTURE("empty.bmp");
+	Chunk& chunk;
 
-	Chunk* chunk;
+	LineCollider collider;
+	Vec2 position;
 
 	// testing, REMOVE
 	Vec2 normal;

--- a/include/terrain/terrainCollider.h
+++ b/include/terrain/terrainCollider.h
@@ -2,6 +2,11 @@
 
 #include "engine/collision.h"
 
+#ifdef DEBUG_GIZMO
+#include <memory>
+class GameObject;
+#endif
+
 class Chunk;
 
 class TerrainCollider : public LineCollider {
@@ -19,6 +24,7 @@ private:
 
 	Vec2 position;
 
-	// testing, REMOVE
-	Vec2 normal;
+#ifdef DEBUG_GIZMO
+	std::unique_ptr<GameObject> fakeObject;
+#endif
 };

--- a/include/terrain/terrainCollider.h
+++ b/include/terrain/terrainCollider.h
@@ -1,22 +1,22 @@
 #pragma once
 
-#include "engine/gameObject.h"
+#include "engine/collision.h"
 
 class Chunk;
 
-class TerrainCollider {
+class TerrainCollider : public LineCollider {
 public:
 	TerrainCollider(Vec2&& position, Vec2&& start, Vec2&& end, Chunk& chunk);
 
-	// ONLY USED FOR DEBUG_GIZMO
-	void update(Scene& scene, const float deltaTime);
+	void update(Scene& scene);
 
-	void onCollision(const Collision::Event& event, Scene& scene);
+	void onCollision(const Collision::Event& event, Scene& scene) override;
+
+	std::string_view getTag() const override { return "Terrain"; }
 
 private:
 	Chunk& chunk;
 
-	LineCollider collider;
 	Vec2 position;
 
 	// testing, REMOVE

--- a/include/terrain/terrainManager.h
+++ b/include/terrain/terrainManager.h
@@ -26,11 +26,18 @@ public:
 	               const int pixelSizeMultiplier, const SDL_Color& color, Scene& scene);
 
 	void update(const Vec2& playerPos);
-	void collisionUpdate(const Vec2& playerPos);
+	void collisionUpdate();
 
 	void updateRender();
 	void updateColliders();
-	void render(SDL_Renderer* renderer, const Camera& cam, const Vec2& playerPos) const;
+	/* Updates the activeChunks variable with all the chunks in range of pos.
+	 * These are the chunks that are rendered and checked for collisions.
+	 *
+	 * @param pos Center position to check from. Probably want this to be the player position.
+	 * @param range Amount of chunks in each direction that will be set as active.
+	 */
+	void updateActiveChunks(const Vec2& pos, const int range);
+	void render(SDL_Renderer* renderer, const Camera& cam) const;
 
 	void changeTerrain(const Vec2& position, const unsigned char value);
 	void changeTerrain(const std::pair<std::size_t, std::size_t>& position,
@@ -68,6 +75,8 @@ private:
 	const std::size_t terrainXSize;
 	const std::size_t terrainYSize;
 	std::vector<std::vector<Chunk>> chunks;
+	constexpr static int chunkRange = 1;
+	std::vector<std::reference_wrapper<Chunk>> activeChunks;
 	std::vector<std::vector<Chunk>> splitToChunks(const Terrain& terrain,
 	                                              const std::size_t chunkSize);
 	std::pair<std::size_t, std::size_t> posToChunk(

--- a/include/terrain/terrainManager.h
+++ b/include/terrain/terrainManager.h
@@ -59,6 +59,7 @@ public:
 	std::size_t getChunksX() const { return chunks.empty() ? 0 : chunks[0].size(); }
 	std::size_t getChunksY() const { return chunks.size(); }
 	std::size_t getChunkSize() const { return chunkSize; }
+	const std::vector<std::vector<Chunk>>& getChunks() const { return chunks; }
 	int getPixelSize() const { return pixelSize; }
 	// DEPRECATED, does not return a correct tree.
 	const Tree2D& getTree() const { return terrainTree; }

--- a/include/terrain/terrainManager.h
+++ b/include/terrain/terrainManager.h
@@ -18,6 +18,9 @@ public:
 	TerrainManager(const Terrain& terrain, const std::size_t chunkSize,
 	               const int pixelSizeMultiplier, const SDL_Color& color, Scene& scene);
 
+	void update();
+	void collisionUpdate();
+
 	void updateRender();
 	void updateColliders();
 	void render(SDL_Renderer* renderer, const Camera& cam) const;

--- a/include/terrain/terrainManager.h
+++ b/include/terrain/terrainManager.h
@@ -18,12 +18,12 @@ public:
 	TerrainManager(const Terrain& terrain, const std::size_t chunkSize,
 	               const int pixelSizeMultiplier, const SDL_Color& color, Scene& scene);
 
-	void update();
+	void update(const Vec2& playerPos);
 	void collisionUpdate();
 
 	void updateRender();
 	void updateColliders();
-	void render(SDL_Renderer* renderer, const Camera& cam) const;
+	void render(SDL_Renderer* renderer, const Camera& cam, const Vec2& playerPos) const;
 
 	void setCell(const Vec2& position, const unsigned char value);
 	void setCell(const std::pair<std::size_t, std::size_t>& position, const unsigned char value);
@@ -64,6 +64,15 @@ private:
 	                                              const std::size_t chunkSize);
 	std::pair<std::size_t, std::size_t> posToChunk(
 	    const std::pair<std::size_t, std::size_t>& pos) const;
+	/* @param x Center X-position in chunk coordinates.
+	 * @param y Center Y-position in chunk coordinates.
+	 */
+	std::vector<std::reference_wrapper<Chunk>> getChunksInRange(const std::size_t x,
+	                                                            const std::size_t y,
+	                                                            const int range);
+	std::vector<std::reference_wrapper<const Chunk>> getConstChunksInRange(const std::size_t x,
+	                                                                       const std::size_t y,
+	                                                                       const int range) const;
 
 	// DEPRECATED. TerrainManager does not know about all it's terrainColliders.
 	std::vector<GameObject*> terrainColliders;

--- a/include/terrain/terrainManager.h
+++ b/include/terrain/terrainManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <queue>
 #include <vector>
 
 #include "SDL2/SDL_pixels.h"
@@ -13,27 +14,34 @@ class Scene;
 class TerrainCollider;
 class Camera;
 
+struct TerrainChange {
+	const std::size_t x;
+	const std::size_t y;
+	const unsigned char value;
+};
+
 class TerrainManager {
 public:
 	TerrainManager(const Terrain& terrain, const std::size_t chunkSize,
 	               const int pixelSizeMultiplier, const SDL_Color& color, Scene& scene);
 
 	void update(const Vec2& playerPos);
-	void collisionUpdate();
+	void collisionUpdate(const Vec2& playerPos);
 
 	void updateRender();
 	void updateColliders();
 	void render(SDL_Renderer* renderer, const Camera& cam, const Vec2& playerPos) const;
 
-	void setCell(const Vec2& position, const unsigned char value);
-	void setCell(const std::pair<std::size_t, std::size_t>& position, const unsigned char value);
-	void setCell(const std::size_t x, const std::size_t y, const unsigned char value);
+	void changeTerrain(const Vec2& position, const unsigned char value);
+	void changeTerrain(const std::pair<std::size_t, std::size_t>& position,
+	                   const unsigned char value);
+	void changeTerrain(const std::size_t x, const std::size_t y, const unsigned char value);
 	/* Removes all pixels in range of the center and recalculates collisions.
 	 *
 	 * @param center Center position to remove from.
 	 * @param range The range to remove from. (Radius of circle).
 	 */
-	void setCellsInRange(const Vec2& center, int range, const unsigned char value);
+	void changeTerrainInRange(const Vec2& center, int range, const unsigned char value);
 	/* Get the array indices of the terrain pixel at the given world position.
 	 *
 	 * @param position Position to translate to indices.
@@ -73,6 +81,9 @@ private:
 	std::vector<std::reference_wrapper<const Chunk>> getConstChunksInRange(const std::size_t x,
 	                                                                       const std::size_t y,
 	                                                                       const int range) const;
+
+	std::queue<TerrainChange> pendingTerrainChanges;
+	void executeTerrainChanges();
 
 	// DEPRECATED. TerrainManager does not know about all it's terrainColliders.
 	std::vector<GameObject*> terrainColliders;

--- a/src/enemies/enemy.cpp
+++ b/src/enemies/enemy.cpp
@@ -6,7 +6,6 @@
 #include "engine/scene.h"
 #include "player.h"
 #include "scenes/combat_scene.h"
-#include "terrain/terrainCollider.h"
 
 Enemy::Enemy(const float health_, const float damage_, const float speed, const float steer,
              const float sMult, const float slowing)
@@ -75,9 +74,7 @@ void Enemy::onCollision(const Collision::Event& event, Scene& scene) {
 		return;
 	}
 
-	const TerrainCollider* terrainCollider =
-	    dynamic_cast<const TerrainCollider*>(event.other->getParent());
-	if (terrainCollider) {
+	if (event.other->getTag() == "Terrain") {
 		position += Collision::resolveStaticLine(event, position);
 		return;
 	}

--- a/src/enemyManager.cpp
+++ b/src/enemyManager.cpp
@@ -4,7 +4,8 @@
 #include "engine/game.h"
 #include "engine/scene.h"
 
-EnemyManager::EnemyManager(std::vector<Vec2>&& spawnPositions) : spawnPositions{spawnPositions} {}
+EnemyManager::EnemyManager(std::vector<Vec2>&& spawnPositions)
+    : spawnPositions{std::move(spawnPositions)} {}
 
 void EnemyManager::update(Scene& scene, const float deltaTime) {
 	// Remove pointer to enemies that will be deleted

--- a/src/engine/collision.cpp
+++ b/src/engine/collision.cpp
@@ -170,7 +170,7 @@ Vec2 resolveStaticLine(const Collision::Event& event, const Vec2& position) {
 	normal = Vec2{normal.y, normal.x * -1};
 	// Check what side of line position is on
 	const float angle = std::acos(normal.normalized().dotProduct(
-	    (position - event.other->getParent()->getPosition()).normalized()));
+	    (position - line.line.position).normalized()));
 	const float degrees = angle * 180 / M_PI;
 	// Calculate movement according to collision depth and what side position is on
 	if (degrees >= 90.0f && degrees <= 180.0f)

--- a/src/engine/collision.cpp
+++ b/src/engine/collision.cpp
@@ -169,8 +169,8 @@ Vec2 resolveStaticLine(const Collision::Event& event, const Vec2& position) {
 	Vec2 normal = Vec2{line.line.start - line.line.end}.normalized();
 	normal = Vec2{normal.y, normal.x * -1};
 	// Check what side of line position is on
-	const float angle = std::acos(normal.normalized().dotProduct(
-	    (position - line.line.position).normalized()));
+	const float angle =
+	    std::acos(normal.normalized().dotProduct((position - line.line.position).normalized()));
 	const float degrees = angle * 180 / M_PI;
 	// Calculate movement according to collision depth and what side position is on
 	if (degrees >= 90.0f && degrees <= 180.0f)
@@ -356,52 +356,52 @@ void LineCollider::checkCollisions(const Scene& scene) {
 	std::vector<std::reference_wrapper<GameObject>> closeObjects;
 	try {
 		// Get all GameObjects withing our bounding circle
-		closeObjects = scene.getObjectTree().findObjectsInRange(line.start, getCheckRadius());
+		closeObjects = scene.getObjectTree().findObjectsInRange(line.position, getCheckRadius());
 	} catch (int e) {
 		std::cerr << "Exception " << e << " when checking collisions. Tree was likely not built.\n";
 		return;
 	}
 
-	for (GameObject& object : closeObjects) {
-		Collider* otherCollider = object.getCollider();
-		// No need to check collision if object is not collideable,
-		// or we know we have already collided,
-		// or if it is "colliding" with itself.
-		if (otherCollider == nullptr || haveCollidedWith.count(otherCollider) ||
-		    &object == getParent())
-			continue;
+		for (GameObject& object : closeObjects) {
+			Collider* otherCollider = object.getCollider();
+			// No need to check collision if object is not collideable,
+			// or we know we have already collided,
+			// or if it is "colliding" with itself.
+			if (otherCollider == nullptr || haveCollidedWith.count(otherCollider) ||
+			    &object == getParent())
+				continue;
 
-		switch (otherCollider->getCollisionType()) {
-			using enum Collision::Types;
+			switch (otherCollider->getCollisionType()) {
+				using enum Collision::Types;
 
-			case CIRCLE: {
-				CircleCollider* otherCircle = static_cast<CircleCollider*>(otherCollider);
-				Collision::Event event = Collision::checkCollision(otherCircle->circle, line);
-				if (event.collided) {
-					event.other = otherCircle;
-					addCollision(event);
-					event.other = this;
-					otherCollider->addCollision(event);
+				case CIRCLE: {
+					CircleCollider* otherCircle = static_cast<CircleCollider*>(otherCollider);
+					Collision::Event event = Collision::checkCollision(otherCircle->circle, line);
+					if (event.collided) {
+						event.other = otherCircle;
+						addCollision(event);
+						event.other = this;
+						otherCollider->addCollision(event);
+					}
+					break;
 				}
-				break;
-			}
-			case LINE: {
-				LineCollider* otherLine = static_cast<LineCollider*>(otherCollider);
-				Collision::Event event = Collision::checkCollision(line, otherLine->line);
-				if (event.collided) {
-					event.other = otherLine;
-					addCollision(event);
-					event.other = this;
-					otherCollider->addCollision(event);
+				case LINE: {
+					LineCollider* otherLine = static_cast<LineCollider*>(otherCollider);
+					Collision::Event event = Collision::checkCollision(line, otherLine->line);
+					if (event.collided) {
+						event.other = otherLine;
+						addCollision(event);
+						event.other = this;
+						otherCollider->addCollision(event);
+					}
+					break;
 				}
-				break;
-			}
-			case POINT: {
-				// Currently no support for Line-Point collision
-				break;
+				case POINT: {
+					// Currently no support for Line-Point collision
+					break;
+				}
 			}
 		}
-	}
 }
 
 void PointCollider::checkCollisions(const Scene& scene) {

--- a/src/engine/collision.cpp
+++ b/src/engine/collision.cpp
@@ -1,6 +1,7 @@
 #include "engine/collision.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <iostream>
 #include <vector>
@@ -362,46 +363,46 @@ void LineCollider::checkCollisions(const Scene& scene) {
 		return;
 	}
 
-		for (GameObject& object : closeObjects) {
-			Collider* otherCollider = object.getCollider();
-			// No need to check collision if object is not collideable,
-			// or we know we have already collided,
-			// or if it is "colliding" with itself.
-			if (otherCollider == nullptr || haveCollidedWith.count(otherCollider) ||
-			    &object == getParent())
-				continue;
+	for (GameObject& object : closeObjects) {
+		Collider* otherCollider = object.getCollider();
+		// No need to check collision if object is not collideable,
+		// or we know we have already collided,
+		// or if it is "colliding" with itself.
+		if (otherCollider == nullptr || haveCollidedWith.count(otherCollider) ||
+		    &object == getParent())
+			continue;
 
-			switch (otherCollider->getCollisionType()) {
-				using enum Collision::Types;
+		switch (otherCollider->getCollisionType()) {
+			using enum Collision::Types;
 
-				case CIRCLE: {
-					CircleCollider* otherCircle = static_cast<CircleCollider*>(otherCollider);
-					Collision::Event event = Collision::checkCollision(otherCircle->circle, line);
-					if (event.collided) {
-						event.other = otherCircle;
-						addCollision(event);
-						event.other = this;
-						otherCollider->addCollision(event);
-					}
-					break;
+			case CIRCLE: {
+				CircleCollider* otherCircle = static_cast<CircleCollider*>(otherCollider);
+				Collision::Event event = Collision::checkCollision(otherCircle->circle, line);
+				if (event.collided) {
+					event.other = otherCircle;
+					addCollision(event);
+					event.other = this;
+					otherCollider->addCollision(event);
 				}
-				case LINE: {
-					LineCollider* otherLine = static_cast<LineCollider*>(otherCollider);
-					Collision::Event event = Collision::checkCollision(line, otherLine->line);
-					if (event.collided) {
-						event.other = otherLine;
-						addCollision(event);
-						event.other = this;
-						otherCollider->addCollision(event);
-					}
-					break;
+				break;
+			}
+			case LINE: {
+				LineCollider* otherLine = static_cast<LineCollider*>(otherCollider);
+				Collision::Event event = Collision::checkCollision(line, otherLine->line);
+				if (event.collided) {
+					event.other = otherLine;
+					addCollision(event);
+					event.other = this;
+					otherCollider->addCollision(event);
 				}
-				case POINT: {
-					// Currently no support for Line-Point collision
-					break;
-				}
+				break;
+			}
+			case POINT: {
+				// Currently no support for Line-Point collision
+				break;
 			}
 		}
+	}
 }
 
 void PointCollider::checkCollisions(const Scene& scene) {

--- a/src/engine/scene.cpp
+++ b/src/engine/scene.cpp
@@ -30,12 +30,6 @@ void Scene::update(const float deltaTime) {
 		if (object->getCollider()->getIsStatic()) continue;  // Don't check static colliders
 		object->getCollider()->checkCollisions(*this);
 	}
-
-	// Update GameObjects according to registered collisions
-	for (auto& object : gameObjects) {
-		if (object->getCollider() == nullptr) continue;
-		object->getCollider()->collisionUpdate(*this);
-	}
 }
 
 void Scene::updateDelete() {
@@ -45,6 +39,13 @@ void Scene::updateDelete() {
 			it = gameObjects.erase(it);  // Delete GameObject
 		} else
 			it++;
+	}
+}
+
+void Scene::updateCollision() {
+	for (auto& object : gameObjects) {
+		if (object->getCollider() == nullptr) continue;
+		object->getCollider()->collisionUpdate(*this);
 	}
 }
 

--- a/src/engine/scene.cpp
+++ b/src/engine/scene.cpp
@@ -4,7 +4,7 @@
 
 Scene::Scene(Game& game_) : game(game_) {}
 
-void Scene::initialize(std::vector<std::unique_ptr<GameObject>>& persistentObjects) {
+void Scene::initialize(GameObjectVector&& persistentObjects) {
 	// Transfer ownership of persistent GameObjects to this scene
 	gameObjects = std::move(persistentObjects);
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1,6 +1,7 @@
 #include "player.h"
 
 #include <cmath>
+#include <iostream>
 #include <memory>
 
 #include "SDL2/SDL_mouse.h"
@@ -106,9 +107,7 @@ void Player::onCollision(const Collision::Event& event, Scene& scene) {
 		return;
 	}
 
-	const TerrainCollider* terrainCollider =
-	    dynamic_cast<const TerrainCollider*>(event.other->getParent());
-	if (terrainCollider) {
+	if (event.other->getTag() == "Terrain") {
 		position += Collision::resolveStaticLine(event, position);
 		return;
 	}

--- a/src/scenes/combat_scene.cpp
+++ b/src/scenes/combat_scene.cpp
@@ -30,6 +30,10 @@ void CombatScene::update(const float deltaTime) {
 	Scene::update(deltaTime);
 
 	enemyManager.update(*this, deltaTime);
+	terrainManager.update();
+
+	Scene::updateCollision();
+	terrainManager.collisionUpdate();
 }
 
 void CombatScene::render(SDL_Renderer* renderer) const {

--- a/src/scenes/combat_scene.cpp
+++ b/src/scenes/combat_scene.cpp
@@ -32,7 +32,7 @@ void CombatScene::update(const float deltaTime) {
 	terrainManager.update(player.getPosition());
 
 	Scene::updateCollision();
-	terrainManager.collisionUpdate(player.getPosition());
+	terrainManager.collisionUpdate();
 
 	enemyManager.update(*this, deltaTime);
 }
@@ -40,7 +40,7 @@ void CombatScene::update(const float deltaTime) {
 void CombatScene::render(SDL_Renderer* renderer) const {
 	Scene::render(renderer);
 
-	terrainManager.render(renderer, getCam(), player.getPosition());
+	terrainManager.render(renderer, getCam());
 }
 
 TerrainManager CombatScene::generateTerrain() {

--- a/src/scenes/combat_scene.cpp
+++ b/src/scenes/combat_scene.cpp
@@ -21,10 +21,6 @@ void CombatScene::initialize() {
 	terrainManager.updateRender();
 }
 
-void CombatScene::initialize(GameObjectVector& persistentObjects) {
-	Scene::initialize(persistentObjects);
-}
-
 void CombatScene::update(const float deltaTime) {
 	if (getGame().getOnMouseDown()[SDL_BUTTON_RIGHT]) {
 		const Vec2 pos = getGame().getMousePos() + cam.getPos();

--- a/src/scenes/combat_scene.cpp
+++ b/src/scenes/combat_scene.cpp
@@ -24,16 +24,17 @@ void CombatScene::initialize() {
 void CombatScene::update(const float deltaTime) {
 	if (getGame().getOnMouseDown()[SDL_BUTTON_RIGHT]) {
 		const Vec2 pos = getGame().getMousePos() + cam.getPos();
-		terrainManager.setCellsInRange(pos, 5, 0);
+		terrainManager.changeTerrainInRange(pos, 5, 0);
 	}
 
 	Scene::update(deltaTime);
 
-	enemyManager.update(*this, deltaTime);
 	terrainManager.update(player.getPosition());
 
 	Scene::updateCollision();
-	terrainManager.collisionUpdate();
+	terrainManager.collisionUpdate(player.getPosition());
+
+	enemyManager.update(*this, deltaTime);
 }
 
 void CombatScene::render(SDL_Renderer* renderer) const {

--- a/src/scenes/combat_scene.cpp
+++ b/src/scenes/combat_scene.cpp
@@ -30,7 +30,7 @@ void CombatScene::update(const float deltaTime) {
 	Scene::update(deltaTime);
 
 	enemyManager.update(*this, deltaTime);
-	terrainManager.update();
+	terrainManager.update(player.getPosition());
 
 	Scene::updateCollision();
 	terrainManager.collisionUpdate();
@@ -39,7 +39,7 @@ void CombatScene::update(const float deltaTime) {
 void CombatScene::render(SDL_Renderer* renderer) const {
 	Scene::render(renderer);
 
-	terrainManager.render(renderer, getCam());
+	terrainManager.render(renderer, getCam(), player.getPosition());
 }
 
 TerrainManager CombatScene::generateTerrain() {

--- a/src/terrain/chunk.cpp
+++ b/src/terrain/chunk.cpp
@@ -30,19 +30,18 @@ void Chunk::collisionUpdate(Scene& scene) {
 	for (TerrainCollider& collider : colliders) collider.collisionUpdate(scene);
 }
 
-void Chunk::setCell(const std::size_t x, const std::size_t y, const unsigned char value) {
-	assert(x >= 0 && x < terrain.getXSize() && y >= 0 && y < terrain.getYSize() &&
-	       "Position (x, y) must be within the terrain size.");
+void Chunk::changeTerrain(const TerrainChange& change) {
+	assert(change.x >= 0 && change.x < terrain.getXSize() && change.y >= 0 &&
+	       change.y < terrain.getYSize() && "Position (x, y) must be within the terrain size.");
 
-	terrain.map[y][x] = value;
+	terrain.map[change.y][change.x] = change.value;
 
 	updateColliders();
 	updateRender(manager.getPixelSize());
 }
 
-void Chunk::setCellMultiple(const std::vector<std::pair<size_t, size_t>>& positions,
-                            const unsigned char value) {
-	for (auto [x, y] : positions) {
+void Chunk::changeTerrainMultiple(const std::vector<TerrainChange>& changes) {
+	for (auto [x, y, value] : changes) {
 		assert(x >= 0 && x < terrain.getXSize() && y >= 0 && y < terrain.getYSize() &&
 		       "Position (x, y) must be within the terrain size.");
 		terrain.map[y][x] = value;

--- a/src/terrain/chunk.cpp
+++ b/src/terrain/chunk.cpp
@@ -22,6 +22,14 @@ Chunk::Chunk(std::vector<std::vector<unsigned char>>&& map, const std::size_t or
 	updateSpawnPositions();
 }
 
+void Chunk::update(Scene& scene) {
+	for (TerrainCollider& collider : colliders) collider.update(scene);
+}
+
+void Chunk::collisionUpdate(Scene& scene) {
+	for (TerrainCollider& collider : colliders) collider.collisionUpdate(scene);
+}
+
 void Chunk::setCell(const std::size_t x, const std::size_t y, const unsigned char value) {
 	assert(x >= 0 && x < terrain.getXSize() && y >= 0 && y < terrain.getYSize() &&
 	       "Position (x, y) must be within the terrain size.");

--- a/src/terrain/chunk.cpp
+++ b/src/terrain/chunk.cpp
@@ -2,7 +2,7 @@
 
 #include <cassert>
 
-#include "engine/scene.h"
+#include "engine/camera.h"
 #include "terrain/terrainCollider.h"
 #include "terrain/terrainManager.h"
 
@@ -49,7 +49,7 @@ void Chunk::render(SDL_Renderer* renderer, const Camera& cam) const {
 	rects.reserve(terrain.getXSize() * terrain.getYSize());
 	for (auto curRects : renderRects) {
 		for (auto& rect : curRects) {
-			const Vec2 camPos = cam.getPos();
+			const Vec2& camPos = cam.getPos();
 			rect.x -= camPos.x;
 			rect.y -= camPos.y;
 		}
@@ -76,7 +76,6 @@ void Chunk::updateRender(const int pixelSize) {
 }
 
 void Chunk::updateColliders() {
-	for (auto& collider : colliders) collider.get().deleteObject = true;
 	colliders.clear();
 
 	std::map<std::pair<int, int>, std::pair<int, int>> currentColliders;  // Key: end, Value: start
@@ -166,12 +165,12 @@ void Chunk::tryExtendCollider(
     const std::pair<int, int>& start, const std::pair<int, int>& end,
     std::map<std::pair<int, int>, std::pair<int, int>>& currentColliders) {
 	const Vec2 startVec{start.first, start.second};
-	const Vec2 endVec{end.first, end.second};
+	Vec2 endVec{end.first, end.second};
 
 	// Create collider if there already is one ending at end
 	auto endIt = currentColliders.find(end);
 	if (endIt != currentColliders.end()) {
-		createCollider(Vec2{endIt->second.first, endIt->second.second}, endVec);
+		createCollider(Vec2{endIt->second.first, endIt->second.second}, std::move(endVec));
 		currentColliders.erase(endIt);
 	}
 
@@ -191,11 +190,9 @@ void Chunk::tryExtendCollider(
 	currentColliders[end] = start;
 }
 
-void Chunk::createCollider(const Vec2& start, const Vec2& end) {
-	const Vec2 position{start + (end - start) * 0.5f};
-	TerrainCollider& collider =
-	    manager.getScene().instantiate<TerrainCollider>(position, start, end, *this);
-	colliders.push_back(collider);
+void Chunk::createCollider(Vec2&& start, Vec2&& end) {
+	Vec2 position{start + (end - start) * 0.5f};
+	colliders.emplace_back(std::move(position), std::move(start), std::move(end), *this);
 }
 
 void Chunk::updateSpawnPositions() {

--- a/src/terrain/terrainCollider.cpp
+++ b/src/terrain/terrainCollider.cpp
@@ -8,41 +8,28 @@
 #include "terrain/chunk.h"
 #include "terrain/terrainManager.h"
 
-TerrainCollider::TerrainCollider() : GameObject{Vec2{}}, chunk{nullptr} {
-	// Create a static line collider and set this GameObject as static
-	collider = std::make_unique<LineCollider>(Collision::Line{}, true, this);
-	isStatic = true;
-	renderObject = false;
-}
-
-void TerrainCollider::initialize(const Scene& scene, const Vec2& position, const Vec2& start,
-                                 const Vec2& end, Chunk& chunk) {
-	GameObject::initialize(scene, position);
-
-	LineCollider* lineCollider = static_cast<LineCollider*>(collider.get());
-	lineCollider->line.start = start;
-	lineCollider->line.end = end;
-
-	this->chunk = &chunk;
-}
+TerrainCollider::TerrainCollider(Vec2&& position, Vec2&& start, Vec2&& end, Chunk& chunk)
+    : chunk{chunk},
+      collider{Collision::Line{position, std::move(start), std::move(end)}, true},
+      position{std::move(position)} {}
 
 void TerrainCollider::onCollision(const Collision::Event& event, Scene& scene) {
 	const Bullet* bullet = dynamic_cast<const Bullet*>(event.other->getParent());
 	if (bullet) {
 		Vec2 newPos = event.position + bullet->getDirection() * 0.1f;
-		const auto [nx, ny] = chunk->getManager().posToTerrainCoord(newPos);
-		const auto [ox, oy] = chunk->getManager().posToTerrainCoord(event.position);
+		const auto [nx, ny] = chunk.getManager().posToTerrainCoord(newPos);
+		const auto [ox, oy] = chunk.getManager().posToTerrainCoord(event.position);
 		if (nx != ox && ny != oy) {
 			// newPos is beyond where it should be able to hit,
 			// so we choose the one closest to the original collision position.
 			const int rx = std::round(newPos.x);
 			const int ry = std::round(newPos.y);
 			if (std::abs(rx - newPos.x) > std::abs(ry - newPos.y))
-				chunk->getManager().setCell(ox, ny, 0);
+				chunk.getManager().setCell(ox, ny, 0);
 			else
-				chunk->getManager().setCell(nx, oy, 0);
+				chunk.getManager().setCell(nx, oy, 0);
 		} else
-			chunk->getManager().setCell(nx, ny, 0);
+			chunk.getManager().setCell(nx, ny, 0);
 	}
 }
 
@@ -51,17 +38,14 @@ void TerrainCollider::update(Scene& scene, const float deltaTime) {
 #ifndef DEBUG_GIZMO
 	return;
 #endif
-	GameObject::update(scene, deltaTime);
-
-	LineCollider* lineCollider = static_cast<LineCollider*>(collider.get());
-	const Vec2 dir = Vec2(lineCollider->line.end - lineCollider->line.start).normalized();
-	normal = Vec2(dir.y, dir.x * -1.0f) * 25.0f;
-	scene.getGame().getRenderManager().addRenderCall(
-	    [this](Scene& scene) {
-		    const Vec2 camPos = scene.getCam().getPos();
-		    SDL_RenderDrawLine(scene.getGame().getRenderer(), position.x - camPos.x,
-		                       position.y - camPos.y, position.x - camPos.x + normal.x,
-		                       position.y - camPos.y + normal.y);
-	    },
-	    this);
+//	const Vec2 dir = Vec2(collider.line.end - collider.line.start).normalized();
+//	normal = Vec2(dir.y, dir.x * -1.0f) * 25.0f;
+//	scene.getGame().getRenderManager().addRenderCall(
+//	    [this](Scene& scene) {
+//		    const Vec2 camPos = scene.getCam().getPos();
+//		    SDL_RenderDrawLine(scene.getGame().getRenderer(), position.x - camPos.x,
+//		                       position.y - camPos.y, position.x - camPos.x + normal.x,
+//		                       position.y - camPos.y + normal.y);
+//	    },
+//	    this);
 }

--- a/src/terrain/terrainCollider.cpp
+++ b/src/terrain/terrainCollider.cpp
@@ -13,14 +13,16 @@ constexpr float collisionCheckRadius = 500.0f;
 TerrainCollider::TerrainCollider(Vec2&& position, Vec2&& start, Vec2&& end, Chunk& chunk)
     : chunk{chunk},
       LineCollider{Collision::Line{std::move(position), std::move(start), std::move(end)},
-                   collisionCheckRadius} {}
+                   collisionCheckRadius} {
+#ifdef DEBUG_GIZMO
+	fakeObject = std::make_unique<GameObject>();
+#endif
+}
 
 void TerrainCollider::update(Scene& scene) {
 	LineCollider::checkCollisions(scene);
 
 #ifdef DEBUG_GIZMO
-	// Using DEBUG_GIZMO causes memory leak here. Will be fixed later.
-	GameObject* temp = new GameObject;
 	scene.getGame().getRenderManager().addRenderCall(
 	    [this](Scene& scene) {
 		    const Vec2& camPos = scene.getCam().getPos();
@@ -29,7 +31,7 @@ void TerrainCollider::update(Scene& scene) {
 		                       line.start.y - camPos.y, line.end.x - camPos.x,
 		                       line.end.y - camPos.y);
 	    },
-	    temp);
+	    fakeObject.get());
 #endif
 }
 
@@ -45,10 +47,10 @@ void TerrainCollider::onCollision(const Collision::Event& event, Scene& scene) {
 			const int rx = std::round(newPos.x);
 			const int ry = std::round(newPos.y);
 			if (std::abs(rx - newPos.x) > std::abs(ry - newPos.y))
-				chunk.getManager().setCell(ox, ny, 0);
+				chunk.getManager().changeTerrain(ox, ny, 0);
 			else
-				chunk.getManager().setCell(nx, oy, 0);
+				chunk.getManager().changeTerrain(nx, oy, 0);
 		} else
-			chunk.getManager().setCell(nx, ny, 0);
+			chunk.getManager().changeTerrain(nx, ny, 0);
 	}
 }

--- a/src/terrain/terrainManager.cpp
+++ b/src/terrain/terrainManager.cpp
@@ -24,9 +24,19 @@ TerrainManager::TerrainManager(const Terrain& terrain, const std::size_t chunkSi
 	updateColliders();
 }
 
+void TerrainManager::update() {
+	for (auto& vec : chunks)
+		for (Chunk& chunk : vec) chunk.update(scene);
+}
+
+void TerrainManager::collisionUpdate() {
+	for (auto& vec : chunks)
+		for (Chunk& chunk : vec) chunk.collisionUpdate(scene);
+}
+
 void TerrainManager::updateRender() {
 	for (auto& vec : chunks)
-		for (auto& chunk : vec) chunk.updateRender(pixelSize);
+		for (Chunk& chunk : vec) chunk.updateRender(pixelSize);
 }
 
 void TerrainManager::updateColliders() {
@@ -35,7 +45,7 @@ void TerrainManager::updateColliders() {
 	terrainColliders.clear();
 
 	for (auto& vec : chunks)
-		for (auto& chunk : vec) chunk.updateColliders();
+		for (Chunk& chunk : vec) chunk.updateColliders();
 
 	updateTree();
 }

--- a/src/terrain/terrainManager.cpp
+++ b/src/terrain/terrainManager.cpp
@@ -27,15 +27,12 @@ TerrainManager::TerrainManager(const Terrain& terrain, const std::size_t chunkSi
 void TerrainManager::update(const Vec2& playerPos) {
 	if (!pendingTerrainChanges.empty()) executeTerrainChanges();
 
-	const auto [chunkX, chunkY] = posToChunk(posToTerrainCoord(playerPos));
-	const auto chunksToUpdate = getChunksInRange(chunkX, chunkY, 10);
-	for (Chunk& chunk : chunksToUpdate) chunk.update(scene);
+	updateActiveChunks(playerPos, chunkRange);
+	for (Chunk& chunk : activeChunks) chunk.update(scene);
 }
 
-void TerrainManager::collisionUpdate(const Vec2& playerPos) {
-	const auto [chunkX, chunkY] = posToChunk(posToTerrainCoord(playerPos));
-	const auto chunksToUpdate = getChunksInRange(chunkX, chunkY, 10);
-	for (Chunk& chunk : chunksToUpdate) chunk.collisionUpdate(scene);
+void TerrainManager::collisionUpdate() {
+	for (Chunk& chunk : activeChunks) chunk.collisionUpdate(scene);
 }
 
 void TerrainManager::updateRender() {
@@ -54,13 +51,15 @@ void TerrainManager::updateColliders() {
 	updateTree();
 }
 
-void TerrainManager::render(SDL_Renderer* renderer, const Camera& cam,
-                            const Vec2& playerPos) const {
+void TerrainManager::updateActiveChunks(const Vec2& pos, const int range) {
+	const auto [x, y] = posToChunk(posToTerrainCoord(pos));
+	activeChunks = getChunksInRange(x, y, range);
+}
+
+void TerrainManager::render(SDL_Renderer* renderer, const Camera& cam) const {
 	SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, color.a);
 
-	const auto [chunkX, chunkY] = posToChunk(posToTerrainCoord(playerPos));
-	const auto chunksToRender = getConstChunksInRange(chunkX, chunkY, 1);
-	for (const Chunk& chunk : chunksToRender) chunk.render(renderer, cam);
+	for (const Chunk& chunk : activeChunks) chunk.render(renderer, cam);
 }
 
 void TerrainManager::changeTerrain(const Vec2& position, const unsigned char value) {

--- a/test/terrain_test.cpp
+++ b/test/terrain_test.cpp
@@ -31,9 +31,10 @@ TEST(Terrain, CollisionGeneration) {
 	Game game{"", 1, 1};
 	MockScene scene{game};
 	const std::size_t chunkSize = terrainMap.size();
-	TerrainManager manager{terrain, chunkSize, 1, SDL_Color{1, 1, 1, 1}, scene};
+	TerrainManager manager{terrain, chunkSize, 1, SDL_Color{}, scene};
+	const Chunk& chunk = manager.getChunks()[0][0];
 
-	constexpr int expected = 44;
-	EXPECT_TRUE(scene.objCount() == expected)
-	    << "Expected " << expected << " colliders, found " << scene.objCount();
+	constexpr std::size_t expected = 44;
+	EXPECT_TRUE(chunk.getColliderCount() == expected)
+	    << "Expected " << expected << " colliders, found " << chunk.getColliderCount();
 }


### PR DESCRIPTION
Closes #143

- The chunks now have ownership of the terrain colliders in that chunk, and are responsible for updating and checking these for collisions, in addition to actually rendering the chunk.
- The TerrainCollider class is no longer a GameObject, and instead inherits from LineCollider.
- TerrainManager keeps track of the chunks close the the player, and only runs updates on these.