### PR TITLE
fix: TerrainCollider fake GameObject memory issue

### DIFF
--- a/include/scenes/combat_scene.h
+++ b/include/scenes/combat_scene.h
@@ -10,8 +10,6 @@ class CombatScene : public Scene {
 public:
 	CombatScene(Game& game_);
 
-	void initialize() override;
-
 	void update(const float deltaTime) override;
 	void render(SDL_Renderer* renderer) const override;
 

--- a/include/terrain/chunk.h
+++ b/include/terrain/chunk.h
@@ -21,6 +21,12 @@ public:
 	Chunk(std::vector<std::vector<unsigned char>>&& map, const std::size_t originX,
 	      const std::size_t originY, TerrainManager& manager);
 
+	// Delete copy
+	Chunk(const Chunk&) = delete;
+	Chunk& operator=(const Chunk&) = delete;
+
+	Chunk(Chunk&&) = default;
+
 	/* Sets the cell at position (x, y) to value.
 	 * x and y position is relative to this chunk.
 	 */

--- a/include/terrain/terrainCollider.h
+++ b/include/terrain/terrainCollider.h
@@ -1,17 +1,21 @@
 #pragma once
 
+#include <memory>
+
 #include "engine/collision.h"
 
-#ifdef DEBUG_GIZMO
-#include <memory>
-class GameObject;
-#endif
-
 class Chunk;
+class GameObject;
 
 class TerrainCollider : public LineCollider {
 public:
 	TerrainCollider(Vec2&& position, Vec2&& start, Vec2&& end, Chunk& chunk);
+
+	// Delete copy
+	TerrainCollider(const TerrainCollider&) = delete;
+	TerrainCollider& operator=(const TerrainCollider&) = delete;
+
+	TerrainCollider(TerrainCollider&&) = default;
 
 	void update(Scene& scene);
 
@@ -24,7 +28,5 @@ private:
 
 	Vec2 position;
 
-#ifdef DEBUG_GIZMO
 	std::unique_ptr<GameObject> fakeObject;
-#endif
 };

--- a/include/terrain/terrainManager.h
+++ b/include/terrain/terrainManager.h
@@ -25,6 +25,12 @@ public:
 	TerrainManager(const Terrain& terrain, const std::size_t chunkSize,
 	               const int pixelSizeMultiplier, const SDL_Color& color, Scene& scene);
 
+	~TerrainManager();
+
+	TerrainManager(const TerrainManager&) = delete;
+	TerrainManager& operator=(const Chunk&) = delete;
+	TerrainManager(TerrainManager&&) = default;
+
 	void update(const Vec2& playerPos);
 	void collisionUpdate();
 

--- a/src/scenes/combat_scene.cpp
+++ b/src/scenes/combat_scene.cpp
@@ -14,13 +14,6 @@ CombatScene::CombatScene(Game& game)
       player{spawnPlayer()},
       enemyManager{std::move(terrainManager.getAllSpawns())} {}
 
-void CombatScene::initialize() {
-	Scene::initialize();
-
-	terrainManager.updateColliders();
-	terrainManager.updateRender();
-}
-
 void CombatScene::update(const float deltaTime) {
 	if (getGame().getOnMouseDown()[SDL_BUTTON_RIGHT]) {
 		const Vec2 pos = getGame().getMousePos() + cam.getPos();

--- a/src/terrain/chunk.cpp
+++ b/src/terrain/chunk.cpp
@@ -17,9 +17,16 @@ std::array<int, Chunk::minSpawnSpace> Chunk::spawnCircleY = [] {
 
 Chunk::Chunk(std::vector<std::vector<unsigned char>>&& map, const std::size_t originX,
              const std::size_t originY, TerrainManager& manager)
-    : terrain{map}, manager{manager}, originX{originX}, originY{originY} {
+    : manager{manager},
+      terrain{std::move(map)},
+      originX{originX},
+      originY{originY},
+      renderRects{},
+      colliders{} {
 	renderRects.resize(terrain.getYSize(), std::vector<SDL_Rect>(terrain.getXSize()));
+	updateColliders();
 	updateSpawnPositions();
+	updateRender(manager.getPixelSize());
 }
 
 void Chunk::update(Scene& scene) {
@@ -163,7 +170,7 @@ void Chunk::updateColliders() {
 	}
 
 	// Construct colliders
-	colliders.reserve(currentColliders.size());
+	colliders.reserve(colliders.size() + currentColliders.size());
 	for (const auto& [end, start] : currentColliders)
 		createCollider(Vec2{start.first, start.second}, Vec2{end.first, end.second});
 }

--- a/src/terrain/terrainCollider.cpp
+++ b/src/terrain/terrainCollider.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "bullet.h"
+#include "enemies/enemy.h"
 #include "engine/game.h"
 #include "engine/scene.h"
 #include "terrain/chunk.h"
@@ -13,10 +14,13 @@ constexpr float collisionCheckRadius = 500.0f;
 TerrainCollider::TerrainCollider(Vec2&& position, Vec2&& start, Vec2&& end, Chunk& chunk)
     : chunk{chunk},
       LineCollider{Collision::Line{std::move(position), std::move(start), std::move(end)},
-                   collisionCheckRadius} {
+                   collisionCheckRadius},
 #ifdef DEBUG_GIZMO
-	fakeObject = std::make_unique<GameObject>();
+      fakeObject{std::make_unique<GameObject>()}
+#else
+      fakeObject{nullptr}
 #endif
+{
 }
 
 void TerrainCollider::update(Scene& scene) {

--- a/src/terrain/terrainManager.cpp
+++ b/src/terrain/terrainManager.cpp
@@ -17,12 +17,11 @@ TerrainManager::TerrainManager(const Terrain& terrain, const std::size_t chunkSi
       pixelSize{Game::pixelSize * pixelSizeMultiplier},
       color{color_},
       scene{scene_},
-      chunks{std::move(splitToChunks(terrain, chunkSize))},
+      chunks{splitToChunks(terrain, chunkSize)},
       terrainXSize{terrain.getXSize()},
-      terrainYSize{terrain.getYSize()} {
-	updateRender();
-	updateColliders();
-}
+      terrainYSize{terrain.getYSize()} {}
+
+TerrainManager::~TerrainManager() = default;
 
 void TerrainManager::update(const Vec2& playerPos) {
 	if (!pendingTerrainChanges.empty()) executeTerrainChanges();
@@ -41,14 +40,8 @@ void TerrainManager::updateRender() {
 }
 
 void TerrainManager::updateColliders() {
-	// Remove previous colliders
-	for (auto collider : terrainColliders) collider->deleteObject = true;
-	terrainColliders.clear();
-
 	for (auto& vec : chunks)
 		for (Chunk& chunk : vec) chunk.updateColliders();
-
-	updateTree();
 }
 
 void TerrainManager::updateActiveChunks(const Vec2& pos, const int range) {

--- a/test/terrain_test.cpp
+++ b/test/terrain_test.cpp
@@ -28,7 +28,7 @@ TEST(Terrain, CollisionGeneration) {
 	};
 
 	Terrain terrain{std::move(terrainMap)};
-	Game game{"", 1, 1};
+	Game game{"", 0, 0};
 	MockScene scene{game};
 	const std::size_t chunkSize = terrainMap.size();
 	TerrainManager manager{terrain, chunkSize, 1, SDL_Color{}, scene};
@@ -37,4 +37,5 @@ TEST(Terrain, CollisionGeneration) {
 	constexpr std::size_t expected = 44;
 	EXPECT_TRUE(chunk.getColliderCount() == expected)
 	    << "Expected " << expected << " colliders, found " << chunk.getColliderCount();
+	game.clean();
 }


### PR DESCRIPTION
Fixes #148 

Problem:
It seems that the TerrainManager was being copied, which caused a shallow copy of the TerrainColliders resulting in a double free. This was only apparent when fakeGameObject was not null, because then (I believe) the destructor was no longer trivial.

Solution:
Delete copy constructors and force move construction for TerrainCollider, Chunk, and TerrainManager.