### PR TITLE
feat: spawn enemies in loaded chunks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(SOURCE_FILES
 "src/engine/Tree2D.cpp"
 "src/scenes/combat_scene.cpp"
 "src/enemies/spider.cpp"
-"src/terrain/terrainManager.cpp"
+"src/terrain/chunkManager.cpp"
 "src/terrain/terrainCollider.cpp"
 "src/terrain/terrainGenerator.cpp"
 "src/terrain/terrain.cpp"

--- a/include/enemyManager.h
+++ b/include/enemyManager.h
@@ -9,9 +9,11 @@ class Game;
 
 class EnemyManager {
 public:
-	EnemyManager(std::vector<Vec2>&& spawnPositions);
+	EnemyManager();
 
-	void update(Scene& scene, const float deltaTime);
+	void update();
+
+	void addEnemy(Enemy& enemy);
 
 	// Returns a vector of all enemies
 	const std::vector<std::reference_wrapper<Enemy>>& getEnemies() const { return enemies; }
@@ -20,13 +22,28 @@ public:
 
 private:
 	std::vector<std::reference_wrapper<Enemy>> enemies;
-	constexpr static float spawnInterval = 3;
-	float spawnTimer = 0;
-
-	std::vector<Vec2> spawnPositions;
-
-	void spawnEnemy(Scene& scene);
 
 	Tree2D enemyTree;
 	void updateTree();
+};
+
+class EnemySpawner {
+public:
+	EnemySpawner(EnemyManager& manager);
+
+	void update(Scene& scene, const float deltaTime);
+
+	void updateSpawnPositions(std::vector<Vec2>&& newSpawns);
+
+private:
+	EnemyManager& manager;
+
+	std::vector<Vec2> spawnPositions;
+
+	float timer;
+	static constexpr float timeMin = 2;
+	static constexpr float timeMax = 5;
+
+	// Randomly chooses a position from spawnPositions and spawns an enemy there.
+	void spawn(Scene& scene);
 };

--- a/include/scenes/combat_scene.h
+++ b/include/scenes/combat_scene.h
@@ -2,7 +2,7 @@
 
 #include "enemyManager.h"
 #include "engine/scene.h"
-#include "terrain/terrainManager.h"
+#include "terrain/chunkManager.h"
 
 class Player;
 
@@ -14,16 +14,16 @@ public:
 	void render(SDL_Renderer* renderer) const override;
 
 	const EnemyManager& getEnemyManager() const { return enemyManager; }
-	const TerrainManager& getTerrainManager() const { return terrainManager; }
+	const ChunkManager& getChunkManager() const { return chunkManager; }
 
 private:
-	TerrainManager terrainManager;
+	ChunkManager chunkManager;
 	EnemyManager enemyManager;
 
-	TerrainManager generateTerrain();
+	ChunkManager generateTerrain();
 	const Player& spawnPlayer();
 
 public:
-	// Player must be initialized after terrainManager
+	// Player must be initialized after chunkManager
 	const Player& player;
 };

--- a/include/scenes/combat_scene.h
+++ b/include/scenes/combat_scene.h
@@ -17,8 +17,8 @@ public:
 	const ChunkManager& getChunkManager() const { return chunkManager; }
 
 private:
-	ChunkManager chunkManager;
 	EnemyManager enemyManager;
+	ChunkManager chunkManager;
 
 	ChunkManager generateTerrain();
 	const Player& spawnPlayer();

--- a/include/terrain/chunk.h
+++ b/include/terrain/chunk.h
@@ -14,12 +14,12 @@ struct Vec2;
 struct SDL_Renderer;
 class Camera;
 class TerrainChange;
-class TerrainManager;
+class ChunkManager;
 
 class Chunk {
 public:
 	Chunk(std::vector<std::vector<unsigned char>>&& map, const std::size_t originX,
-	      const std::size_t originY, TerrainManager& manager);
+	      const std::size_t originY, ChunkManager& manager);
 
 	// Delete copy
 	Chunk(const Chunk&) = delete;
@@ -44,12 +44,12 @@ public:
 
 	void updateSpawnPositions();
 
-	TerrainManager& getManager() const { return manager; }
+	ChunkManager& getManager() const { return manager; }
 	const Terrain& getTerrain() const { return terrain; }
 	const std::vector<Vec2>& getSpawnPositions() const { return spawnPositions; }
 
 private:
-	TerrainManager& manager;
+	ChunkManager& manager;
 
 	Terrain terrain;
 	const std::size_t originX;

--- a/include/terrain/chunk.h
+++ b/include/terrain/chunk.h
@@ -6,6 +6,7 @@
 #include <optional>
 
 #include "SDL2/SDL_rect.h"
+#include "enemyManager.h"
 #include "terrain/terrain.h"
 #include "terrain/terrainCollider.h"
 
@@ -19,7 +20,7 @@ class ChunkManager;
 class Chunk {
 public:
 	Chunk(std::vector<std::vector<unsigned char>>&& map, const std::size_t originX,
-	      const std::size_t originY, ChunkManager& manager);
+	      const std::size_t originY, ChunkManager& manager, EnemyManager& enemyManager);
 
 	// Delete copy
 	Chunk(const Chunk&) = delete;
@@ -29,8 +30,8 @@ public:
 
 	enum States {
 		NORMAL = 0,  // Not in any of the other categories
-		CENTER, // The center chunk (usually the one the player is in)
-		EDGE,  // Chunks at the edge of what is loaded.
+		CENTER,      // The center chunk (usually the one the player is in)
+		EDGE,        // Chunks at the edge of what is loaded.
 	};
 	States state;
 
@@ -40,7 +41,7 @@ public:
 	void changeTerrain(const TerrainChange& change);
 	void changeTerrainMultiple(const std::vector<TerrainChange>& changes);
 
-	void update(Scene& scene);
+	void update(Scene& scene, const float deltaTime);
 	void collisionUpdate(Scene& scene);
 
 	void render(SDL_Renderer* renderer, const Camera& cam) const;
@@ -50,10 +51,10 @@ public:
 	std::size_t getColliderCount() const { return colliders.size(); }
 
 	void updateSpawnPositions();
+	std::vector<Vec2> findSpawnPositions() const;
 
 	ChunkManager& getManager() const { return manager; }
 	const Terrain& getTerrain() const { return terrain; }
-	const std::vector<Vec2>& getSpawnPositions() const { return spawnPositions; }
 
 private:
 	ChunkManager& manager;
@@ -83,9 +84,9 @@ private:
 	 */
 	void createCollider(Vec2&& start, Vec2&& end);
 
+	EnemySpawner enemySpawner;
 	static constexpr int minSpawnSpace = 15;
 	static std::array<int, minSpawnSpace> spawnCircleY;
-	std::vector<Vec2> spawnPositions;
 	// @return Position where there is terrain blocking. Has no value if none were found.
 	std::optional<std::pair<std::size_t, std::size_t>> findObstruction(const std::size_t x,
 	                                                                   const std::size_t y,

--- a/include/terrain/chunk.h
+++ b/include/terrain/chunk.h
@@ -27,6 +27,13 @@ public:
 
 	Chunk(Chunk&&) = default;
 
+	enum States {
+		NORMAL = 0,  // Not in any of the other categories
+		CENTER, // The center chunk (usually the one the player is in)
+		EDGE,  // Chunks at the edge of what is loaded.
+	};
+	States state;
+
 	/* Sets the cell at position (x, y) to value.
 	 * x and y position is relative to this chunk.
 	 */

--- a/include/terrain/chunkManager.h
+++ b/include/terrain/chunkManager.h
@@ -20,16 +20,16 @@ struct TerrainChange {
 	const unsigned char value;
 };
 
-class TerrainManager {
+class ChunkManager {
 public:
-	TerrainManager(const Terrain& terrain, const std::size_t chunkSize,
-	               const int pixelSizeMultiplier, const SDL_Color& color, Scene& scene);
+	ChunkManager(const Terrain& terrain, const std::size_t chunkSize, const int pixelSizeMultiplier,
+	             const SDL_Color& color, Scene& scene);
 
-	~TerrainManager();
+	~ChunkManager();
 
-	TerrainManager(const TerrainManager&) = delete;
-	TerrainManager& operator=(const Chunk&) = delete;
-	TerrainManager(TerrainManager&&) = default;
+	ChunkManager(const ChunkManager&) = delete;
+	ChunkManager& operator=(const Chunk&) = delete;
+	ChunkManager(ChunkManager&&) = default;
 
 	void update(const Vec2& playerPos);
 	void collisionUpdate();

--- a/include/terrain/chunkManager.h
+++ b/include/terrain/chunkManager.h
@@ -75,6 +75,8 @@ public:
 
 private:
 	Scene& scene;
+	// ChunkManager needs a reference to the EnemyManager because the EnemySpawner in each chunk
+	// needs a reference to the EnemyManager.
 	EnemyManager& enemyManager;
 
 	int pixelSize;

--- a/include/terrain/chunkManager.h
+++ b/include/terrain/chunkManager.h
@@ -23,7 +23,7 @@ struct TerrainChange {
 class ChunkManager {
 public:
 	ChunkManager(const Terrain& terrain, const std::size_t chunkSize, const int pixelSizeMultiplier,
-	             const SDL_Color& color, Scene& scene);
+	             const SDL_Color& color, Scene& scene, EnemyManager& enemyManager);
 
 	~ChunkManager();
 
@@ -31,7 +31,7 @@ public:
 	ChunkManager& operator=(const Chunk&) = delete;
 	ChunkManager(ChunkManager&&) = default;
 
-	void update(const Vec2& playerPos);
+	void update(const float deltaTime, const Vec2& playerPos);
 	void collisionUpdate();
 
 	void updateRender();
@@ -75,6 +75,7 @@ public:
 
 private:
 	Scene& scene;
+	EnemyManager& enemyManager;
 
 	int pixelSize;
 

--- a/include/terrain/terrainGenerator.h
+++ b/include/terrain/terrainGenerator.h
@@ -5,7 +5,7 @@
 
 #include "terrain/terrain.h"
 
-class TerrainManager;
+class ChunkManager;
 
 class TerrainGenerator {
 public:

--- a/src/enemies/enemy.cpp
+++ b/src/enemies/enemy.cpp
@@ -149,7 +149,7 @@ void Enemy::avoidTerrain(const float strength, const float avoidDist) {
 	try {
 		// Find closest terrain object
 		const GameObject* closest =
-		    combatScene->getTerrainManager().getTree().findClosestObject(position);
+		    combatScene->getChunkManager().getTree().findClosestObject(position);
 		// Find the closest point to this enemy on the LineCollider
 		const Collision::Line& line = static_cast<LineCollider*>(closest->getCollider())->line;
 		const Vec2 closestPoint = Collision::closestPointOnLine(position, line);

--- a/src/scenes/combat_scene.cpp
+++ b/src/scenes/combat_scene.cpp
@@ -68,7 +68,8 @@ ChunkManager CombatScene::generateTerrain() {
 	constexpr std::size_t chunkSize = 100;
 	constexpr int pixelSizeMultiplier = 3;
 	constexpr SDL_Color terrainColor{56, 28, 40, 255};
-	ChunkManager manager{terrain, chunkSize, pixelSizeMultiplier, terrainColor, *this, enemyManager};
+	ChunkManager manager{terrain,      chunkSize, pixelSizeMultiplier,
+	                     terrainColor, *this,     enemyManager};
 	return manager;
 }
 

--- a/src/scenes/combat_scene.cpp
+++ b/src/scenes/combat_scene.cpp
@@ -10,22 +10,22 @@
 
 CombatScene::CombatScene(Game& game)
     : Scene{game},
-      terrainManager{generateTerrain()},
+      chunkManager{generateTerrain()},
       player{spawnPlayer()},
-      enemyManager{std::move(terrainManager.getAllSpawns())} {}
+      enemyManager{std::move(chunkManager.getAllSpawns())} {}
 
 void CombatScene::update(const float deltaTime) {
 	if (getGame().getOnMouseDown()[SDL_BUTTON_RIGHT]) {
 		const Vec2 pos = getGame().getMousePos() + cam.getPos();
-		terrainManager.changeTerrainInRange(pos, 5, 0);
+		chunkManager.changeTerrainInRange(pos, 5, 0);
 	}
 
 	Scene::update(deltaTime);
 
-	terrainManager.update(player.getPosition());
+	chunkManager.update(player.getPosition());
 
 	Scene::updateCollision();
-	terrainManager.collisionUpdate();
+	chunkManager.collisionUpdate();
 
 	enemyManager.update(*this, deltaTime);
 }
@@ -33,10 +33,10 @@ void CombatScene::update(const float deltaTime) {
 void CombatScene::render(SDL_Renderer* renderer) const {
 	Scene::render(renderer);
 
-	terrainManager.render(renderer, getCam());
+	chunkManager.render(renderer, getCam());
 }
 
-TerrainManager CombatScene::generateTerrain() {
+ChunkManager CombatScene::generateTerrain() {
 	TerrainGenerator gen{game.randGen};
 	// Shape parameters
 	gen.shapeFillProb = 0.2;
@@ -71,12 +71,12 @@ TerrainManager CombatScene::generateTerrain() {
 	constexpr std::size_t chunkSize = 100;
 	constexpr int pixelSizeMultiplier = 3;
 	constexpr SDL_Color terrainColor{56, 28, 40, 255};
-	TerrainManager manager{terrain, chunkSize, pixelSizeMultiplier, terrainColor, *this};
+	ChunkManager manager{terrain, chunkSize, pixelSizeMultiplier, terrainColor, *this};
 	return manager;
 }
 
 const Player& CombatScene::spawnPlayer() {
-	const auto spawns = terrainManager.getAllSpawns();
+	const auto spawns = chunkManager.getAllSpawns();
 	std::uniform_int_distribution<std::size_t> dist{0, spawns.size() - 1};
 	const std::size_t idx = dist(game.randGen);
 	const Vec2 spawnPos = spawns[idx];

--- a/src/scenes/combat_scene.cpp
+++ b/src/scenes/combat_scene.cpp
@@ -9,10 +9,7 @@
 #include "terrain/terrainGenerator.h"
 
 CombatScene::CombatScene(Game& game)
-    : Scene{game},
-      chunkManager{generateTerrain()},
-      player{spawnPlayer()},
-      enemyManager{std::move(chunkManager.getAllSpawns())} {}
+    : Scene{game}, enemyManager{}, chunkManager{generateTerrain()}, player{spawnPlayer()} {}
 
 void CombatScene::update(const float deltaTime) {
 	if (getGame().getOnMouseDown()[SDL_BUTTON_RIGHT]) {
@@ -22,12 +19,12 @@ void CombatScene::update(const float deltaTime) {
 
 	Scene::update(deltaTime);
 
-	chunkManager.update(player.getPosition());
+	chunkManager.update(deltaTime, player.getPosition());
 
 	Scene::updateCollision();
 	chunkManager.collisionUpdate();
 
-	enemyManager.update(*this, deltaTime);
+	enemyManager.update();
 }
 
 void CombatScene::render(SDL_Renderer* renderer) const {
@@ -71,7 +68,7 @@ ChunkManager CombatScene::generateTerrain() {
 	constexpr std::size_t chunkSize = 100;
 	constexpr int pixelSizeMultiplier = 3;
 	constexpr SDL_Color terrainColor{56, 28, 40, 255};
-	ChunkManager manager{terrain, chunkSize, pixelSizeMultiplier, terrainColor, *this};
+	ChunkManager manager{terrain, chunkSize, pixelSizeMultiplier, terrainColor, *this, enemyManager};
 	return manager;
 }
 

--- a/src/terrain/chunk.cpp
+++ b/src/terrain/chunk.cpp
@@ -4,7 +4,7 @@
 
 #include "engine/camera.h"
 #include "terrain/terrainCollider.h"
-#include "terrain/terrainManager.h"
+#include "terrain/chunkManager.h"
 
 std::array<int, Chunk::minSpawnSpace> Chunk::spawnCircleY = [] {
 	std::array<int, minSpawnSpace> result;
@@ -16,7 +16,7 @@ std::array<int, Chunk::minSpawnSpace> Chunk::spawnCircleY = [] {
 }();
 
 Chunk::Chunk(std::vector<std::vector<unsigned char>>&& map, const std::size_t originX,
-             const std::size_t originY, TerrainManager& manager)
+             const std::size_t originY, ChunkManager& manager)
     : manager{manager},
       terrain{std::move(map)},
       originX{originX},

--- a/src/terrain/chunk.cpp
+++ b/src/terrain/chunk.cpp
@@ -32,7 +32,7 @@ Chunk::Chunk(std::vector<std::vector<unsigned char>>&& map, const std::size_t or
 }
 
 void Chunk::update(Scene& scene, const float deltaTime) {
-	enemySpawner.update(scene, deltaTime);
+	if (state == EDGE) enemySpawner.update(scene, deltaTime);
 	for (TerrainCollider& collider : colliders) collider.update(scene);
 }
 

--- a/src/terrain/chunk.cpp
+++ b/src/terrain/chunk.cpp
@@ -3,8 +3,8 @@
 #include <cassert>
 
 #include "engine/camera.h"
-#include "terrain/terrainCollider.h"
 #include "terrain/chunkManager.h"
+#include "terrain/terrainCollider.h"
 
 std::array<int, Chunk::minSpawnSpace> Chunk::spawnCircleY = [] {
 	std::array<int, minSpawnSpace> result;
@@ -16,21 +16,23 @@ std::array<int, Chunk::minSpawnSpace> Chunk::spawnCircleY = [] {
 }();
 
 Chunk::Chunk(std::vector<std::vector<unsigned char>>&& map, const std::size_t originX,
-             const std::size_t originY, ChunkManager& manager)
+             const std::size_t originY, ChunkManager& manager, EnemyManager& enemyManager)
     : state{},
-	manager{manager},
+      manager{manager},
       terrain{std::move(map)},
       originX{originX},
       originY{originY},
       renderRects{},
-      colliders{} {
+      colliders{},
+      enemySpawner{enemyManager} {
 	renderRects.resize(terrain.getYSize(), std::vector<SDL_Rect>(terrain.getXSize()));
 	updateColliders();
 	updateSpawnPositions();
 	updateRender(manager.getPixelSize());
 }
 
-void Chunk::update(Scene& scene) {
+void Chunk::update(Scene& scene, const float deltaTime) {
+	enemySpawner.update(scene, deltaTime);
 	for (TerrainCollider& collider : colliders) collider.update(scene);
 }
 
@@ -210,8 +212,10 @@ void Chunk::createCollider(Vec2&& start, Vec2&& end) {
 	colliders.emplace_back(std::move(position), std::move(start), std::move(end), *this);
 }
 
-void Chunk::updateSpawnPositions() {
-	spawnPositions.clear();
+void Chunk::updateSpawnPositions() { enemySpawner.updateSpawnPositions(findSpawnPositions()); }
+
+std::vector<Vec2> Chunk::findSpawnPositions() const {
+	std::vector<Vec2> positions;
 
 	Terrain used{terrain.map};
 	for (std::size_t y = minSpawnSpace; y < terrain.getYSize() - minSpawnSpace; y++) {
@@ -225,8 +229,8 @@ void Chunk::updateSpawnPositions() {
 				x = hitX + minSpawnSpace - (std::max(hitY, y) - std::min(hitY, y)) +
 				    spawnCircleY.back() + 1;
 			} else {
-				spawnPositions.push_back(Vec2{x * manager.getPixelSize() + originX,
-				                              y * manager.getPixelSize() + originY});
+				positions.emplace_back(x * manager.getPixelSize() + originX,
+				                       y * manager.getPixelSize() + originY);
 
 				// Set all positions inside the spawn area as used.
 				const int cornerDist = spawnCircleY.back() - 1;
@@ -241,6 +245,8 @@ void Chunk::updateSpawnPositions() {
 			}
 		}
 	}
+
+	return positions;
 }
 
 std::optional<std::pair<std::size_t, std::size_t>> Chunk::findObstruction(

--- a/src/terrain/chunk.cpp
+++ b/src/terrain/chunk.cpp
@@ -17,7 +17,8 @@ std::array<int, Chunk::minSpawnSpace> Chunk::spawnCircleY = [] {
 
 Chunk::Chunk(std::vector<std::vector<unsigned char>>&& map, const std::size_t originX,
              const std::size_t originY, ChunkManager& manager)
-    : manager{manager},
+    : state{},
+	manager{manager},
       terrain{std::move(map)},
       originX{originX},
       originY{originY},

--- a/src/terrain/chunkManager.cpp
+++ b/src/terrain/chunkManager.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <iostream>
 
 #include "SDL2/SDL_render.h"
 #include "engine/game.h"
@@ -47,38 +48,52 @@ void ChunkManager::updateColliders() {
 
 void ChunkManager::updateActiveChunks(const Vec2& pos, const int range) {
 	const auto [midX, midY] = posToChunk(posToTerrainCoord(pos));
+	activeChunks.clear();
 
 	// Set top chunks to EDGE
 	if (midY >= range) {
 		std::size_t startX = std::max(static_cast<std::size_t>(0), midX - range);
 		std::size_t endX = std::min(getChunksX() - 1, midX + range);
-		for (std::size_t x = startX; x <= endX; x++) chunks[midY - range][x].state = Chunk::EDGE;
+		for (std::size_t x = startX; x <= endX; x++) {
+			chunks[midY - range][x].state = Chunk::EDGE;
+			activeChunks.emplace_back(chunks[midY - range][x]);
+		}
 	}
 	// Set bottom chunks to EDGE
 	if (midY + range < getChunksY()) {
 		std::size_t startX = std::max(static_cast<std::size_t>(0), midX - range);
 		std::size_t endX = std::min(getChunksX() - 1, midX + range);
-		for (std::size_t x = startX; x <= endX; x++) chunks[midY + range][x].state = Chunk::EDGE;
+		for (std::size_t x = startX; x <= endX; x++) {
+			chunks[midY + range][x].state = Chunk::EDGE;
+			activeChunks.emplace_back(chunks[midY + range][x]);
+		}
 	}
 	// Set leftmost chunks to EDGE
 	if (midX >= range) {
 		std::size_t startY = std::max(static_cast<std::size_t>(0), midY - range + 1);
 		std::size_t endY = std::min(getChunksY() - 1, midY + range - 1);
-		for (std::size_t y = startY; y <= endY; y++) chunks[y][midX - range].state = Chunk::EDGE;
+		for (std::size_t y = startY; y <= endY; y++) {
+			chunks[y][midX - range].state = Chunk::EDGE;
+			activeChunks.emplace_back(chunks[y][midX - range]);
+		}
 	}
 	// Set rightmost chunks to EDGE
 	if (midX + range < getChunksX()) {
-		std::size_t startY = std::max(static_cast<std::size_t>(0), midY - range);
-		std::size_t endY = std::min(getChunksY() - 1, midY + range);
-		for (std::size_t y = startY; y <= endY; y++) chunks[y][midX + range].state = Chunk::EDGE;
+		std::cout << "si" << std::endl;
+		std::size_t startY = std::max(static_cast<std::size_t>(0), midY - range + 1);
+		std::size_t endY = std::min(getChunksY() - 1, midY + range - 1);
+		for (std::size_t y = startY; y <= endY; y++) {
+			chunks[y][midX + range].state = Chunk::EDGE;
+			activeChunks.emplace_back(chunks[y][midX + range]);
+			std::cout << "muy bien" << std::endl;
+		}
 	}
 
 	// Get the rest of the chunks that are not on the edge
-	auto normalChunks = getChunksInRange(midX, midY, range);
+	auto normalChunks = getChunksInRange(midX, midY, range - 1);
 	for (Chunk& chunk : normalChunks) chunk.state = Chunk::NORMAL;
 	chunks[midY][midX].state = Chunk::CENTER;
 
-	activeChunks.clear();
 	activeChunks.insert(activeChunks.end(), normalChunks.begin(), normalChunks.end());
 }
 

--- a/src/terrain/chunkManager.cpp
+++ b/src/terrain/chunkManager.cpp
@@ -47,30 +47,38 @@ void ChunkManager::updateColliders() {
 
 void ChunkManager::updateActiveChunks(const Vec2& pos, const int range) {
 	const auto [midX, midY] = posToChunk(posToTerrainCoord(pos));
-	activeChunks.clear();
 
-	// Set top and bottom chunks to EDGE
-	for (std::size_t x = midX - range; x <= midX + range; x++) {
-		chunks[midY - range][x].state = Chunk::EDGE;
-		activeChunks.emplace_back(chunks[midY - range][x]);
-
-		chunks[midY + range][x].state = Chunk::EDGE;
-		activeChunks.emplace_back(chunks[midY + range][x]);
+	// Set top chunks to EDGE
+	if (midY >= range) {
+		std::size_t startX = std::max(static_cast<std::size_t>(0), midX - range);
+		std::size_t endX = std::min(getChunksX() - 1, midX + range);
+		for (std::size_t x = startX; x <= endX; x++) chunks[midY - range][x].state = Chunk::EDGE;
 	}
-	// Set leftmost and rightmost chunks to EDGE
-	for (std::size_t y = midY - range + 1; y < midY + range; y++) {
-		chunks[y][midX - range].state = Chunk::EDGE;
-		activeChunks.emplace_back(chunks[y][midX - range]);
-
-		chunks[y][midX + range].state = Chunk::EDGE;
-		activeChunks.emplace_back(chunks[y][midX + range]);
+	// Set bottom chunks to EDGE
+	if (midY + range < getChunksY()) {
+		std::size_t startX = std::max(static_cast<std::size_t>(0), midX - range);
+		std::size_t endX = std::min(getChunksX() - 1, midX + range);
+		for (std::size_t x = startX; x <= endX; x++) chunks[midY + range][x].state = Chunk::EDGE;
+	}
+	// Set leftmost chunks to EDGE
+	if (midX >= range) {
+		std::size_t startY = std::max(static_cast<std::size_t>(0), midY - range + 1);
+		std::size_t endY = std::min(getChunksY() - 1, midY + range - 1);
+		for (std::size_t y = startY; y <= endY; y++) chunks[y][midX - range].state = Chunk::EDGE;
+	}
+	// Set rightmost chunks to EDGE
+	if (midX + range < getChunksX()) {
+		std::size_t startY = std::max(static_cast<std::size_t>(0), midY - range);
+		std::size_t endY = std::min(getChunksY() - 1, midY + range);
+		for (std::size_t y = startY; y <= endY; y++) chunks[y][midX + range].state = Chunk::EDGE;
 	}
 
 	// Get the rest of the chunks that are not on the edge
-	auto normalChunks = getChunksInRange(midX, midY, range - 1);
+	auto normalChunks = getChunksInRange(midX, midY, range);
 	for (Chunk& chunk : normalChunks) chunk.state = Chunk::NORMAL;
 	chunks[midY][midX].state = Chunk::CENTER;
 
+	activeChunks.clear();
 	activeChunks.insert(activeChunks.end(), normalChunks.begin(), normalChunks.end());
 }
 

--- a/src/terrain/chunkManager.cpp
+++ b/src/terrain/chunkManager.cpp
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
-#include <iostream>
 
 #include "SDL2/SDL_render.h"
 #include "engine/game.h"
@@ -50,44 +49,28 @@ void ChunkManager::updateActiveChunks(const Vec2& pos, const int range) {
 	const auto [midX, midY] = posToChunk(posToTerrainCoord(pos));
 	activeChunks.clear();
 
+	std::size_t startX = std::max(static_cast<std::size_t>(0), midX - range);
+	std::size_t endX = std::min(getChunksX() - 1, midX + range);
+	std::size_t startY = std::max(static_cast<std::size_t>(0), midY - range + 1);
+	std::size_t endY = std::min(getChunksY() - 1, midY + range - 1);
+
+	auto setChunkAsEdge = [this](Chunk& chunk) {
+		chunk.state = Chunk::EDGE;
+		activeChunks.emplace_back(chunk);
+	};
+
 	// Set top chunks to EDGE
-	if (midY >= range) {
-		std::size_t startX = std::max(static_cast<std::size_t>(0), midX - range);
-		std::size_t endX = std::min(getChunksX() - 1, midX + range);
-		for (std::size_t x = startX; x <= endX; x++) {
-			chunks[midY - range][x].state = Chunk::EDGE;
-			activeChunks.emplace_back(chunks[midY - range][x]);
-		}
-	}
+	if (midY >= range)
+		for (std::size_t x = startX; x <= endX; x++) setChunkAsEdge(chunks[midY - range][x]);
 	// Set bottom chunks to EDGE
-	if (midY + range < getChunksY()) {
-		std::size_t startX = std::max(static_cast<std::size_t>(0), midX - range);
-		std::size_t endX = std::min(getChunksX() - 1, midX + range);
-		for (std::size_t x = startX; x <= endX; x++) {
-			chunks[midY + range][x].state = Chunk::EDGE;
-			activeChunks.emplace_back(chunks[midY + range][x]);
-		}
-	}
+	if (midY + range < getChunksY())
+		for (std::size_t x = startX; x <= endX; x++) setChunkAsEdge(chunks[midY + range][x]);
 	// Set leftmost chunks to EDGE
-	if (midX >= range) {
-		std::size_t startY = std::max(static_cast<std::size_t>(0), midY - range + 1);
-		std::size_t endY = std::min(getChunksY() - 1, midY + range - 1);
-		for (std::size_t y = startY; y <= endY; y++) {
-			chunks[y][midX - range].state = Chunk::EDGE;
-			activeChunks.emplace_back(chunks[y][midX - range]);
-		}
-	}
+	if (midX >= range)
+		for (std::size_t y = startY; y <= endY; y++) setChunkAsEdge(chunks[y][midX - range]);
 	// Set rightmost chunks to EDGE
-	if (midX + range < getChunksX()) {
-		std::cout << "si" << std::endl;
-		std::size_t startY = std::max(static_cast<std::size_t>(0), midY - range + 1);
-		std::size_t endY = std::min(getChunksY() - 1, midY + range - 1);
-		for (std::size_t y = startY; y <= endY; y++) {
-			chunks[y][midX + range].state = Chunk::EDGE;
-			activeChunks.emplace_back(chunks[y][midX + range]);
-			std::cout << "muy bien" << std::endl;
-		}
-	}
+	if (midX + range < getChunksX())
+		for (std::size_t y = startY; y <= endY; y++) setChunkAsEdge(chunks[y][midX + range]);
 
 	// Get the rest of the chunks that are not on the edge
 	auto normalChunks = getChunksInRange(midX, midY, range - 1);

--- a/src/terrain/chunkManager.cpp
+++ b/src/terrain/chunkManager.cpp
@@ -1,4 +1,4 @@
-#include "terrain/terrainManager.h"
+#include "terrain/chunkManager.h"
 
 #include <cassert>
 #include <cmath>
@@ -10,9 +10,8 @@
 #include "terrain/chunk.h"
 #include "terrain/terrainCollider.h"
 
-TerrainManager::TerrainManager(const Terrain& terrain, const std::size_t chunkSize,
-                               const int pixelSizeMultiplier, const SDL_Color& color_,
-                               Scene& scene_)
+ChunkManager::ChunkManager(const Terrain& terrain, const std::size_t chunkSize,
+                           const int pixelSizeMultiplier, const SDL_Color& color_, Scene& scene_)
     : chunkSize{chunkSize},
       pixelSize{Game::pixelSize * pixelSizeMultiplier},
       color{color_},
@@ -21,58 +20,57 @@ TerrainManager::TerrainManager(const Terrain& terrain, const std::size_t chunkSi
       terrainXSize{terrain.getXSize()},
       terrainYSize{terrain.getYSize()} {}
 
-TerrainManager::~TerrainManager() = default;
+ChunkManager::~ChunkManager() = default;
 
-void TerrainManager::update(const Vec2& playerPos) {
+void ChunkManager::update(const Vec2& playerPos) {
 	if (!pendingTerrainChanges.empty()) executeTerrainChanges();
 
 	updateActiveChunks(playerPos, chunkRange);
 	for (Chunk& chunk : activeChunks) chunk.update(scene);
 }
 
-void TerrainManager::collisionUpdate() {
+void ChunkManager::collisionUpdate() {
 	for (Chunk& chunk : activeChunks) chunk.collisionUpdate(scene);
 }
 
-void TerrainManager::updateRender() {
+void ChunkManager::updateRender() {
 	for (auto& vec : chunks)
 		for (Chunk& chunk : vec) chunk.updateRender(pixelSize);
 }
 
-void TerrainManager::updateColliders() {
+void ChunkManager::updateColliders() {
 	for (auto& vec : chunks)
 		for (Chunk& chunk : vec) chunk.updateColliders();
 }
 
-void TerrainManager::updateActiveChunks(const Vec2& pos, const int range) {
+void ChunkManager::updateActiveChunks(const Vec2& pos, const int range) {
 	const auto [x, y] = posToChunk(posToTerrainCoord(pos));
 	activeChunks = getChunksInRange(x, y, range);
 }
 
-void TerrainManager::render(SDL_Renderer* renderer, const Camera& cam) const {
+void ChunkManager::render(SDL_Renderer* renderer, const Camera& cam) const {
 	SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, color.a);
 
 	for (const Chunk& chunk : activeChunks) chunk.render(renderer, cam);
 }
 
-void TerrainManager::changeTerrain(const Vec2& position, const unsigned char value) {
+void ChunkManager::changeTerrain(const Vec2& position, const unsigned char value) {
 	const auto pixelPos = posToTerrainCoord(position);
 	changeTerrain(pixelPos, value);
 }
 
-void TerrainManager::changeTerrain(const std::pair<std::size_t, std::size_t>& position,
-                                   const unsigned char value) {
+void ChunkManager::changeTerrain(const std::pair<std::size_t, std::size_t>& position,
+                                 const unsigned char value) {
 	changeTerrain(position.first, position.second, value);
 }
 
-void TerrainManager::changeTerrain(const std::size_t x, const std::size_t y,
-                                   const unsigned char value) {
+void ChunkManager::changeTerrain(const std::size_t x, const std::size_t y,
+                                 const unsigned char value) {
 	if (x >= terrainXSize || y >= terrainYSize) return;
 	pendingTerrainChanges.emplace(x, y, value);
 }
 
-void TerrainManager::changeTerrainInRange(const Vec2& center, int range,
-                                          const unsigned char value) {
+void ChunkManager::changeTerrainInRange(const Vec2& center, int range, const unsigned char value) {
 	++range;  // Increment range to make calculations work correctly
 
 	// Find the height (sine) of every x position based on the range (radius)
@@ -94,7 +92,7 @@ void TerrainManager::changeTerrainInRange(const Vec2& center, int range,
 	}
 }
 
-void TerrainManager::executeTerrainChanges() {
+void ChunkManager::executeTerrainChanges() {
 	std::map<std::pair<std::size_t, std::size_t>, std::vector<TerrainChange>> chunkMap;
 
 	while (!pendingTerrainChanges.empty()) {
@@ -112,13 +110,13 @@ void TerrainManager::executeTerrainChanges() {
 	}
 }
 
-std::pair<std::size_t, std::size_t> TerrainManager::posToTerrainCoord(const Vec2& position) const {
+std::pair<std::size_t, std::size_t> ChunkManager::posToTerrainCoord(const Vec2& position) const {
 	const std::size_t x = position.x / pixelSize;
 	const std::size_t y = position.y / pixelSize;
 	return std::make_pair(x, y);
 }
 
-std::pair<std::size_t, std::size_t> TerrainManager::posToChunk(
+std::pair<std::size_t, std::size_t> ChunkManager::posToChunk(
     const std::pair<std::size_t, std::size_t>& pos) const {
 	assert(chunkSize != 0);
 
@@ -127,8 +125,8 @@ std::pair<std::size_t, std::size_t> TerrainManager::posToChunk(
 	return std::move(std::make_pair(x, y));
 }
 
-std::vector<std::vector<Chunk>> TerrainManager::splitToChunks(const Terrain& terrain,
-                                                              const std::size_t chunkSize) {
+std::vector<std::vector<Chunk>> ChunkManager::splitToChunks(const Terrain& terrain,
+                                                            const std::size_t chunkSize) {
 	assert(terrain.getXSize() % chunkSize == 0 && terrain.getYSize() % chunkSize == 0 &&
 	       "chunkSize must divide terrain x- and y-size.");
 
@@ -156,9 +154,9 @@ std::vector<std::vector<Chunk>> TerrainManager::splitToChunks(const Terrain& ter
 	return result;
 }
 
-std::vector<std::reference_wrapper<Chunk>> TerrainManager::getChunksInRange(const std::size_t midX,
-                                                                            const std::size_t midY,
-                                                                            const int range) {
+std::vector<std::reference_wrapper<Chunk>> ChunkManager::getChunksInRange(const std::size_t midX,
+                                                                          const std::size_t midY,
+                                                                          const int range) {
 	std::vector<std::reference_wrapper<Chunk>> result;
 	const std::size_t minX = (midX > range) ? midX - range : 0;
 	const std::size_t maxX = std::min(midX + range, getChunksX() - 1);
@@ -171,7 +169,7 @@ std::vector<std::reference_wrapper<Chunk>> TerrainManager::getChunksInRange(cons
 	return result;
 }
 
-std::vector<std::reference_wrapper<const Chunk>> TerrainManager::getConstChunksInRange(
+std::vector<std::reference_wrapper<const Chunk>> ChunkManager::getConstChunksInRange(
     const std::size_t midX, const std::size_t midY, const int range) const {
 	std::vector<std::reference_wrapper<const Chunk>> result;
 	const std::size_t minX = std::max(midX - range, static_cast<std::size_t>(0));
@@ -185,7 +183,7 @@ std::vector<std::reference_wrapper<const Chunk>> TerrainManager::getConstChunksI
 	return result;
 }
 
-std::vector<Vec2> TerrainManager::getAllSpawns() const {
+std::vector<Vec2> ChunkManager::getAllSpawns() const {
 	std::vector<Vec2> spawns;
 	for (const auto& chunkList : chunks) {
 		for (const Chunk& chunk : chunkList) {

--- a/src/terrain/chunkManager.cpp
+++ b/src/terrain/chunkManager.cpp
@@ -44,8 +44,32 @@ void ChunkManager::updateColliders() {
 }
 
 void ChunkManager::updateActiveChunks(const Vec2& pos, const int range) {
-	const auto [x, y] = posToChunk(posToTerrainCoord(pos));
-	activeChunks = getChunksInRange(x, y, range);
+	const auto [midX, midY] = posToChunk(posToTerrainCoord(pos));
+	activeChunks.clear();
+
+	// Set top and bottom chunks to EDGE
+	for (std::size_t x = midX - range; x <= midX + range; x++) {
+		chunks[midY - range][x].state = Chunk::EDGE;
+		activeChunks.emplace_back(chunks[midY - range][x]);
+
+		chunks[midY + range][x].state = Chunk::EDGE;
+		activeChunks.emplace_back(chunks[midY + range][x]);
+	}
+	// Set leftmost and rightmost chunks to EDGE
+	for (std::size_t y = midY - range + 1; y < midY + range; y++) {
+		chunks[y][midX - range].state = Chunk::EDGE;
+		activeChunks.emplace_back(chunks[y][midX - range]);
+
+		chunks[y][midX + range].state = Chunk::EDGE;
+		activeChunks.emplace_back(chunks[y][midX + range]);
+	}
+
+	// Get the rest of the chunks that are not on the edge
+	auto normalChunks = getChunksInRange(midX, midY, range - 1);
+	for (Chunk& chunk : normalChunks) chunk.state = Chunk::NORMAL;
+	chunks[midY][midX].state = Chunk::CENTER;
+
+	activeChunks.insert(activeChunks.end(), normalChunks.begin(), normalChunks.end());
 }
 
 void ChunkManager::render(SDL_Renderer* renderer, const Camera& cam) const {

--- a/src/terrain/terrainCollider.cpp
+++ b/src/terrain/terrainCollider.cpp
@@ -7,7 +7,7 @@
 #include "engine/game.h"
 #include "engine/scene.h"
 #include "terrain/chunk.h"
-#include "terrain/terrainManager.h"
+#include "terrain/chunkManager.h"
 
 constexpr float collisionCheckRadius = 500.0f;
 

--- a/test/terrain_test.cpp
+++ b/test/terrain_test.cpp
@@ -31,7 +31,8 @@ TEST(Terrain, CollisionGeneration) {
 	Game game{"", 0, 0};
 	MockScene scene{game};
 	const std::size_t chunkSize = terrainMap.size();
-	ChunkManager manager{terrain, chunkSize, 1, SDL_Color{}, scene};
+	EnemyManager enemyManager{};
+	ChunkManager manager{terrain, chunkSize, 1, SDL_Color{}, scene, enemyManager};
 	const Chunk& chunk = manager.getChunks()[0][0];
 
 	constexpr std::size_t expected = 44;

--- a/test/terrain_test.cpp
+++ b/test/terrain_test.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "mockScene.h"
-#include "terrain/terrainManager.h"
+#include "terrain/chunkManager.h"
 
 TEST(Terrain, CollisionGeneration) {
 	const std::vector<std::vector<unsigned char>> terrainMap{
@@ -31,7 +31,7 @@ TEST(Terrain, CollisionGeneration) {
 	Game game{"", 0, 0};
 	MockScene scene{game};
 	const std::size_t chunkSize = terrainMap.size();
-	TerrainManager manager{terrain, chunkSize, 1, SDL_Color{}, scene};
+	ChunkManager manager{terrain, chunkSize, 1, SDL_Color{}, scene};
 	const Chunk& chunk = manager.getChunks()[0][0];
 
 	constexpr std::size_t expected = 44;


### PR DESCRIPTION
Closes #153 
- TerrainManager is renamed to ChunkManager.
- Chunks are now in control of spawning enemies, each with their own EnemySpawner member.
- Chunks now have different states (normal, center, and edge). Only chunks in the edge state spawn enemies.